### PR TITLE
Fix autosave interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ https://groups.google.com/d/msg/darknet/NbJqonJBTSY/Te5PfIpuCAAJ
 
 8. Start training by using the command line: `darknet.exe detector train data/obj.data yolo-obj.cfg darknet19_448.conv.23`
 
-    (file `yolo-obj_xxx.weights` will be saved to the `build\darknet\x64\backup\` for each 100 iterations until 1000 iterations has been reached, and after for each 1000 iterations)
+    (file `yolo-obj_xxx.weights` will be saved to the `build\darknet\x64\backup\` for each 100 iterations)
 
 9. After training is complete - get result `yolo-obj_final.weights` from path `build\darknet\x64\backup\`
 


### PR DESCRIPTION
In the current code it simply saves every 100 iterations. I changed the readme to reflect that.
In detector.c atm:
```
//if (i % 1000 == 0 || (i < 1000 && i % 100 == 0)) {
if (i % 100 == 0) { 
...
```
