### PR TITLE
Output improvements for detector results:

### DIFF
--- a/src/box.h
+++ b/src/box.h
@@ -30,6 +30,9 @@ typedef struct detection {
 	float *mask;
 	float objectness;
 	int sort_class;
+	// The most probable class id: the best class index in this->prob.
+	// Is filled temporary when processing results, otherwise not initialized
+	int best_class;
 } detection;
 
 box float_to_box(float *f);

--- a/src/box.h
+++ b/src/box.h
@@ -30,10 +30,14 @@ typedef struct detection {
 	float *mask;
 	float objectness;
 	int sort_class;
+} detection;
+
+typedef struct detection_with_class {
+	detection det;
 	// The most probable class id: the best class index in this->prob.
 	// Is filled temporary when processing results, otherwise not initialized
 	int best_class;
-} detection;
+} detection_with_class;
 
 box float_to_box(float *f);
 float box_iou(box a, box b);
@@ -45,5 +49,9 @@ YOLODLL_API void do_nms_sort(detection *dets, int total, int classes, float thre
 YOLODLL_API void do_nms_obj(detection *dets, int total, int classes, float thresh);
 box decode_box(box b, box anchor);
 box encode_box(box b, box anchor);
+
+// Creates array of detections with prob > thresh and fills best_class for them
+// Return number of selected detections in *selected_detections_num
+detection_with_class* get_actual_detections(detection *dets, int dets_num, float thresh, int* selected_detections_num);
 
 #endif

--- a/src/convolutional_layer.c
+++ b/src/convolutional_layer.c
@@ -491,7 +491,7 @@ void resize_convolutional_layer(convolutional_layer *l, int w, int h)
 	size_t total_byte;
 	check_error(cudaMemGetInfo(&free_byte, &total_byte));
 	if (l->workspace_size > free_byte || l->workspace_size >= total_byte / 2) {
-		printf(" used slow CUDNN algo without Workspace! \n");
+		printf(" used slow CUDNN algo without Workspace! Need memory: %d, available: %d\n", l->workspace_size, (free_byte < total_byte/2) ? free_byte : total_byte/2);
 		cudnn_convolutional_setup(l, cudnn_smallest);
 		l->workspace_size = get_workspace_size(*l);
 	}

--- a/src/darknet.c
+++ b/src/darknet.c
@@ -13,7 +13,7 @@
 #endif
 
 extern void predict_classifier(char *datacfg, char *cfgfile, char *weightfile, char *filename, int top);
-extern void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filename, float thresh);
+extern void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filename, float thresh, int ext_output);
 extern void run_voxel(int argc, char **argv);
 extern void run_yolo(int argc, char **argv);
 extern void run_detector(int argc, char **argv);
@@ -382,8 +382,9 @@ int main(int argc, char **argv)
         run_detector(argc, argv);
     } else if (0 == strcmp(argv[1], "detect")){
         float thresh = find_float_arg(argc, argv, "-thresh", .24);
+		int ext_output = find_arg(argc, argv, "-ext_output");
         char *filename = (argc > 4) ? argv[4]: 0;
-        test_detector("cfg/coco.data", argv[2], argv[3], filename, thresh);
+        test_detector("cfg/coco.data", argv[2], argv[3], filename, thresh, ext_output);
     } else if (0 == strcmp(argv[1], "cifar")){
         run_cifar(argc, argv);
     } else if (0 == strcmp(argv[1], "go")){

--- a/src/detector.c
+++ b/src/detector.c
@@ -1036,7 +1036,8 @@ void calc_anchors(char *datacfg, int num_of_clusters, int width, int height, int
 }
 #endif // OPENCV
 
-void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filename, float thresh, float hier_thresh, int dont_show)
+void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filename, float thresh,
+				   float hier_thresh, int dont_show, int ext_output)
 {
     list *options = read_data_cfg(datacfg);
     char *name_list = option_find_str(options, "names", "data/names.list");
@@ -1088,7 +1089,7 @@ void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filenam
 		int nboxes = 0;
 		detection *dets = get_network_boxes(&net, im.w, im.h, thresh, hier_thresh, 0, 1, &nboxes, letterbox);
 		if (nms) do_nms_sort(dets, nboxes, l.classes, nms);
-		draw_detections_v3(im, dets, nboxes, thresh, names, alphabet, l.classes);
+		draw_detections_v3(im, dets, nboxes, thresh, names, alphabet, l.classes, ext_output);
 		free_detections(dets, nboxes);
         save_image(im, "predictions");
 		if (!dont_show) {
@@ -1124,6 +1125,9 @@ void run_detector(int argc, char **argv)
 	int num_of_clusters = find_int_arg(argc, argv, "-num_of_clusters", 5);
 	int width = find_int_arg(argc, argv, "-width", -1);
 	int height = find_int_arg(argc, argv, "-height", -1);
+	// extended output in test mode (output of rect bound coords)
+	// and for recall mode (extended output table-like format with results for best_class fit)
+	int ext_output = find_arg(argc, argv, "-ext_output");
     if(argc < 4){
         fprintf(stderr, "usage: %s %s [train/test/valid] [cfg] [weights (optional)]\n", argv[0], argv[1]);
         return;
@@ -1160,7 +1164,7 @@ void run_detector(int argc, char **argv)
 		if(strlen(weights) > 0)
 			if (weights[strlen(weights) - 1] == 0x0d) weights[strlen(weights) - 1] = 0;
     char *filename = (argc > 6) ? argv[6]: 0;
-    if(0==strcmp(argv[2], "test")) test_detector(datacfg, cfg, weights, filename, thresh, hier_thresh, dont_show);
+    if(0==strcmp(argv[2], "test")) test_detector(datacfg, cfg, weights, filename, thresh, hier_thresh, dont_show, ext_output);
     else if(0==strcmp(argv[2], "train")) train_detector(datacfg, cfg, weights, gpus, ngpus, clear, dont_show);
     else if(0==strcmp(argv[2], "valid")) validate_detector(datacfg, cfg, weights, outfile);
     else if(0==strcmp(argv[2], "recall")) validate_detector_recall(datacfg, cfg, weights);

--- a/src/image.c
+++ b/src/image.c
@@ -229,27 +229,70 @@ image **load_alphabet()
     return alphabets;
 }
 
-void draw_detections_v3(image im, detection *dets, int num, float thresh, char **names, image **alphabet, int classes)
-{
-	int i, j;
 
-	for (i = 0; i < num; ++i) {
-		char labelstr[4096] = { 0 };
-		int class_id = -1;
-		for (j = 0; j < classes; ++j) {
+
+// Creates array of detections with prob > thresh and fills best_class for them
+detection** get_actual_detections(detection *dets, int dets_num, int classes, float thresh, int* selected_detections_num)
+{
+	int selected_num = 0;
+	detection** result_arr = calloc(dets_num, sizeof(detection*));
+	for (int i = 0; i < dets_num; ++i) {
+		dets[i].best_class = -1;
+		for (int j = 0; j < classes; ++j) {
 			if (dets[i].prob[j] > thresh) {
-				if (class_id < 0) {
-					strcat(labelstr, names[j]);
-					class_id = j;
+				if (dets[i].best_class < 0 || dets[i].prob[dets[i].best_class] < dets[i].prob[j]) {
+					dets[i].best_class = j;
 				}
-				else {
-					strcat(labelstr, ", ");
-					strcat(labelstr, names[j]);
-				}
-				printf("%s: %.0f%%\n", names[j], dets[i].prob[j] * 100);
 			}
 		}
-		if (class_id >= 0) {
+		if (dets[i].best_class >= 0) {
+			result_arr[selected_num] = &(dets[i]);
+			++selected_num;
+		}
+	}
+	if (selected_detections_num)
+		*selected_detections_num = selected_num;
+	return result_arr;
+}
+
+// compare to sort detection** by bbox.x
+int compare_by_lefts(const void *a, const void *b) {
+	const float delta = ((*(detection**)a)->bbox.x - (*(detection**)a)->bbox.w / 2) - ((*(detection**)b)->bbox.x - (*(detection**)b)->bbox.w / 2);
+	return delta < 0 ? -1 : delta > 0 ? 1 : 0;
+}
+
+// compare to sort detection** by best_class probability 
+int compare_by_probs(const void *a_ptr, const void *b_ptr) {
+	const detection* a = *(detection**)a_ptr;
+	const detection* b = *(detection**)b_ptr;
+	float delta = a->prob[a->best_class] - b->prob[b->best_class];
+	return delta < 0 ? -1 : delta > 0 ? 1 : 0;
+}
+
+void draw_detections_v3(image im, detection *dets, int num, float thresh, char **names, image **alphabet, int classes)
+{
+	int selected_detections_num;
+	detection** selected_detections = get_actual_detections(dets, num, classes, thresh, &selected_detections_num);
+
+	// text output
+	qsort(selected_detections, selected_detections_num, sizeof(*selected_detections), compare_by_lefts);
+	for (int i = 0; i < selected_detections_num; ++i) {
+		const int best_class = selected_detections[i]->best_class;
+		printf("%s: %.0f%%\t(left: %.0f\ttop: %.0f\tw: %0.f\th: %0.f)\n", names[best_class],
+			selected_detections[i]->prob[best_class] * 100,
+			(selected_detections[i]->bbox.x - selected_detections[i]->bbox.w / 2)*im.w,
+			(selected_detections[i]->bbox.y - selected_detections[i]->bbox.h / 2)*im.h,
+			selected_detections[i]->bbox.w*im.w, selected_detections[i]->bbox.h*im.h);
+		for (int j = 0; j < classes; ++j) {
+			if (selected_detections[i]->prob[j] > thresh && j != best_class) {
+				printf("%s: %.0f%%\n", names[j], selected_detections[i]->prob[j] * 100);
+			}
+		}
+	}
+
+	// image output
+	qsort(selected_detections, selected_detections_num, sizeof(*selected_detections), compare_by_probs);
+	for (int i = 0; i < selected_detections_num; ++i) {
 			int width = im.h * .006;
 			if (width < 1)
 				width = 1;
@@ -261,8 +304,8 @@ void draw_detections_v3(image im, detection *dets, int num, float thresh, char *
 			}
 			*/
 
-			//printf("%d %s: %.0f%%\n", i, names[class_id], prob*100);
-			int offset = class_id * 123457 % classes;
+			//printf("%d %s: %.0f%%\n", i, names[dets[i].best_class], prob*100);
+			int offset = selected_detections[i]->best_class * 123457 % classes;
 			float red = get_color(2, offset, classes);
 			float green = get_color(1, offset, classes);
 			float blue = get_color(0, offset, classes);
@@ -273,7 +316,7 @@ void draw_detections_v3(image im, detection *dets, int num, float thresh, char *
 			rgb[0] = red;
 			rgb[1] = green;
 			rgb[2] = blue;
-			box b = dets[i].bbox;
+			box b = selected_detections[i]->bbox;
 			//printf("%f %f %f %f\n", b.x, b.y, b.w, b.h);
 
 			int left = (b.x - b.w / 2.)*im.w;
@@ -294,12 +337,20 @@ void draw_detections_v3(image im, detection *dets, int num, float thresh, char *
 
 			draw_box_width(im, left, top, right, bot, width, red, green, blue);
 			if (alphabet) {
+				char labelstr[4096] = { 0 };
+				strcat(labelstr, names[selected_detections[i]->best_class]);
+				for (int j = 0; j < classes; ++j) {
+					if (selected_detections[i]->prob[j] > thresh && j != selected_detections[i]->best_class) {
+						strcat(labelstr, ", ");
+						strcat(labelstr, names[j]);
+					}
+				}
 				image label = get_label_v3(alphabet, labelstr, (im.h*.03));
 				draw_label(im, top + width, left, label, rgb);
 				free_image(label);
 			}
-			if (dets[i].mask) {
-				image mask = float_to_image(14, 14, 1, dets[i].mask);
+			if (selected_detections[i]->mask) {
+				image mask = float_to_image(14, 14, 1, selected_detections[i]->mask);
 				image resized_mask = resize_image(mask, b.w*im.w, b.h*im.h);
 				image tmask = threshold_image(resized_mask, .5);
 				embed_image(tmask, im, left, top);
@@ -307,8 +358,8 @@ void draw_detections_v3(image im, detection *dets, int num, float thresh, char *
 				free_image(resized_mask);
 				free_image(tmask);
 			}
-		}
 	}
+	free(selected_detections);
 }
 
 void draw_detections(image im, int num, float thresh, box *boxes, float **probs, char **names, image **alphabet, int classes)

--- a/src/image.h
+++ b/src/image.h
@@ -23,7 +23,7 @@ void draw_bbox(image a, box bbox, int w, float r, float g, float b);
 void draw_label(image a, int r, int c, image label, const float *rgb);
 void write_label(image a, int r, int c, image *characters, char *string, float *rgb);
 void draw_detections(image im, int num, float thresh, box *boxes, float **probs, char **names, image **labels, int classes);
-void draw_detections_v3(image im, detection *dets, int num, float thresh, char **names, image **alphabet, int classes);
+void draw_detections_v3(image im, detection *dets, int num, float thresh, char **names, image **alphabet, int classes, int ext_output);
 image image_distance(image a, image b);
 void scale_image(image m, float s);
 image crop_image(image im, int dx, int dy, int w, int h);


### PR DESCRIPTION
When printing detector results, output was done in random order, obfuscating results for interpreting. Now:
1. Text output includes coordinates of rects in (left,right,top,bottom in pixels) along with label and score
2. Text output is sorted by rect lefts to simplify finding appropriate rects on image
3. If several class probs are above threshold for some detection, the most probable one is written first and coordinates for others are not repeated
4. Rects are imprinted in image in order from low to high probability, so most probable rects are always on top and are not overlayed by less probable ones.
5. Most probable label for rect is always written first
Also:
6. Message about low GPU memory includes required memory size