### PR TITLE
Change matplotlib backend to 'agg' when 'show_plot' is false. 

### DIFF
--- a/scripts/log_parser/log_parser.py
+++ b/scripts/log_parser/log_parser.py
@@ -10,8 +10,8 @@ import os
 import platform
 import re
 import sys
-
 import matplotlib.pyplot as plt
+
 from matplotlib.ticker import MultipleLocator, FormatStrFormatter
 
 
@@ -98,6 +98,8 @@ def log_parser(args):
     plt.savefig(save_path, dpi=300)
     if args.show_plot:
         plt.show()
+    else:
+        plt.switch_backend('agg')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This allows the script to be run from command line without any errors (for ex, on a remote machine).

This is a follow-up of https://github.com/AlexeyAB/darknet/pull/759