### PR TITLE
Fix openCV 3.4.1 highgui

### DIFF
--- a/src/http_stream.cpp
+++ b/src/http_stream.cpp
@@ -44,7 +44,7 @@ using std::cerr;
 using std::endl;
 
 #include "opencv2/opencv.hpp"
-#include "opencv2/highgui.hpp"
+#include "opencv2/highgui/highgui.hpp"
 #include "opencv2/highgui/highgui_c.h"
 #include "opencv2/imgproc/imgproc_c.h"
 #ifndef CV_VERSION_EPOCH


### PR DESCRIPTION
Fix the compile error of OpenCV 3.4.1 highgui in `http_stream.cpp`