### PR TITLE
Net color depth is exposed from Detector class

### DIFF
--- a/src/yolo_v2_class.cpp
+++ b/src/yolo_v2_class.cpp
@@ -119,6 +119,10 @@ YOLODLL_API int Detector::get_net_height() const {
 	detector_gpu_t &detector_gpu = *static_cast<detector_gpu_t *>(detector_gpu_ptr.get());
 	return detector_gpu.net.h;
 }
+YOLODLL_API int Detector::get_net_color_depth() const {
+	detector_gpu_t &detector_gpu = *static_cast<detector_gpu_t *>(detector_gpu_ptr.get());
+	return detector_gpu.net.c;
+}
 
 
 YOLODLL_API std::vector<bbox_t> Detector::detect(std::string image_filename, float thresh, bool use_mean)

--- a/src/yolo_v2_class.hpp
+++ b/src/yolo_v2_class.hpp
@@ -57,6 +57,7 @@ public:
 	static YOLODLL_API void free_image(image_t m);
 	YOLODLL_API int get_net_width() const;
 	YOLODLL_API int get_net_height() const;
+	YOLODLL_API int get_net_color_depth() const;
 
 	YOLODLL_API std::vector<bbox_t> tracking_id(std::vector<bbox_t> cur_bbox_vec, bool const change_history = true, 
 												int const frames_story = 10, int const max_dist = 150);


### PR DESCRIPTION
Otherwise there is no way to validate that image color depth is the same as net expected color depth