### PR TITLE
Fix initialize frames_counter

### DIFF
--- a/src/yolo_v2_class.cpp
+++ b/src/yolo_v2_class.cpp
@@ -283,6 +283,7 @@ YOLODLL_API std::vector<bbox_t> Detector::detect(image_t img, float thresh, bool
 			bbox.obj_id = obj_id;
 			bbox.prob = prob;
 			bbox.track_id = 0;
+			bbox.frames_counter = 0;
 
 			bbox_vec.push_back(bbox);
 		}


### PR DESCRIPTION
Sometimes 'frames_counter' has wrong number and thus the detection box is still there after the object was gone. 
Tested with the Jetson TX2(Jetpack 3.2).