### PR TITLE
Image resize fix

### DIFF
--- a/src/yolo_console_dll.cpp
+++ b/src/yolo_console_dll.cpp
@@ -310,7 +310,7 @@ int main(int argc, char *argv[])
                     if(consumed)
                     {
                         std::unique_lock<std::mutex> lock(mtx);
-                        det_image = detector.mat_to_image_resize(cur_frame);
+                        det_image = detector.mat_to_image(cur_frame);
                         auto old_result_vec = detector.tracking_id(result_vec);
                         auto detected_result_vec = thread_result_vec;
                         result_vec = detected_result_vec;
@@ -366,8 +366,7 @@ int main(int argc, char *argv[])
                             auto current_image = det_image;
                             consumed = true;
                             while (current_image.use_count() > 0 && !exit_flag) {
-                                auto result = detector.detect_resized(*current_image, frame_size.width, frame_size.height, 
-                                    thresh, false);    // true
+                                auto result = detector.detect(*current_image, thresh, false);    // true
                                 ++fps_det_counter;
                                 std::unique_lock<std::mutex> lock(mtx);
                                 thread_result_vec = result;

--- a/src/yolo_v2_class.cpp
+++ b/src/yolo_v2_class.cpp
@@ -309,10 +309,10 @@ YOLODLL_API std::vector<bbox_t> Detector::detect(image_t img, float thresh, bool
         if (prob > thresh) 
         {
             bbox_t bbox;
-            bbox.x = std::max((double)0, (b.x - b.w / 2.) * scale) - offset_x;
-            bbox.y = std::max((double)0, (b.y - b.h / 2.) * scale) - offset_y;
-            bbox.w = b.w * scale;
-            bbox.h = b.h * scale;
+            bbox.x = std::max((double)0, (b.x - b.w / 2.) * net.w * scale) - offset_x;
+            bbox.y = std::max((double)0, (b.y - b.h / 2.) * net.h * scale) - offset_y;
+            bbox.w = b.w * net.w * scale;
+            bbox.h = b.h * net.h * scale;
             bbox.obj_id = obj_id;
             bbox.prob = prob;
             bbox.track_id = 0;

--- a/src/yolo_v2_class.hpp
+++ b/src/yolo_v2_class.hpp
@@ -74,37 +74,13 @@ public:
     YOLODLL_API std::vector<bbox_t> tracking_id(std::vector<bbox_t> cur_bbox_vec, bool const change_history = true,
                                                 int const frames_story = 10, int const max_dist = 150);
 
-    std::vector<bbox_t> detect_resized(image_t img, int init_w, int init_h, float thresh = 0.2, bool use_mean = false)
-    {
-        if (img.data == NULL)
-            throw std::runtime_error("Image is empty");
-        auto detection_boxes = detect(img, thresh, use_mean);
-        float wk = (float)init_w / img.w, hk = (float)init_h / img.h;
-        for (auto &i : detection_boxes) i.x *= wk, i.w *= wk, i.y *= hk, i.h *= hk;
-        return detection_boxes;
-    }
-
 #ifdef OPENCV
     std::vector<bbox_t> detect(cv::Mat mat, float thresh = 0.2, bool use_mean = false)
     {
         if(mat.data == NULL)
             throw std::runtime_error("Image is empty");
-        auto image_ptr = mat_to_image_resize(mat);
-        return detect_resized(*image_ptr, mat.cols, mat.rows, thresh, use_mean);
-    }
-
-    std::shared_ptr<image_t> mat_to_image_resize(cv::Mat mat) const
-    {
-        if (mat.data == NULL) return std::shared_ptr<image_t>(NULL);
-
-        cv::Size network_size = cv::Size(get_net_width(), get_net_height());
-        cv::Mat det_mat;
-        if (mat.size() != network_size)
-            cv::resize(mat, det_mat, network_size);
-        else
-            det_mat = mat;  // only reference is copied
-
-        return mat_to_image(det_mat);
+        auto image_ptr = mat_to_image(mat);
+        return detect(*image_ptr, thresh, use_mean);
     }
 
     static std::shared_ptr<image_t> mat_to_image(cv::Mat img_src)


### PR DESCRIPTION
Fix for incorrect image resize. Image was not "letterboxed"(just resized with aspect ratio distortions) when using API function Detector::detect from yolo_v2_class.cpp.
Since resize is already performed inside Detector::detect, functions detect_resize and mat_to_image_resize were removed.
