### PR TITLE
Change shebang

### DIFF
--- a/darknet.py
+++ b/darknet.py
@@ -1,4 +1,4 @@
-#!python3
+#!/usr/bin/env python3
 """
 Python 3 wrapper for identifying objects in images
 
@@ -278,7 +278,7 @@ netMain = None
 metaMain = None
 altNames = None
 
-def performDetect(imagePath="data/dog.jpg", thresh= 0.25, configPath = "./cfg/yolov3.cfg", weightPath = "yolov3.weights", metaPath= "./data/coco.data", showImage= True, makeImageOnly = False, initOnly= False):
+def performDetect(imagePath="data/dog.jpg", thresh= 0.25, configPath = "./cfg/yolov3.cfg", weightPath = "yolov3.weights", metaPath= "./cfg/coco.data", showImage= True, makeImageOnly = False, initOnly= False):
     """
     Convenience function to handle the detection and returns of objects.
 


### PR DESCRIPTION
- For portability, change `#!python3` to `#!/usr/bin/env python3`
- Change a parameter because the project moves `data/coco.data` to `cfg/coco.data`

Thank you. 

BTW, since OpenCV C API is deprecated, you know, `./image_yolov3.sh` will not work with 3.4.1 and later. In the fact, darknet is not worked because cvSaveImage is broken in macOS (https://github.com/opencv/opencv/issues/11076). I think `darknet.py` is a new replacement to test which the system can run darknet or not. 