### PR TITLE
Bad memory allocation

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -179,7 +179,7 @@ network make_network(int n)
     network net = {0};
     net.n = n;
     net.layers = calloc(net.n, sizeof(layer));
-    net.seen = calloc(1, sizeof(int));
+    net.seen = calloc(1, sizeof(uint64_t));
 #ifdef GPU
     net.input_gpu = calloc(1, sizeof(float *));
     net.truth_gpu = calloc(1, sizeof(float *));


### PR DESCRIPTION
the variable [network->seen is declared uint64_t* ](https://github.com/AlexeyAB/darknet/blob/master/include/darknet.h#L519), but constructing function allocates only 4 bytes for (int) here