### PR TITLE
fix cuda build on appveyor, remove old unsupported config on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,6 @@ matrix:
 
     - os: osx
       compiler: gcc
-      name: macOS - gcc@5 - opencv@2
-      env:
-        - MATRIX_EVAL="brew install gcc@5 opencv@2 && CC=gcc-5 && CXX=g++-5 && OpenCV_DIR=/usr/local/opt/opencv@2"
-
-    - os: osx
-      compiler: gcc
-      name: macOS - gcc@5 - opencv@3
-      env:
-        - MATRIX_EVAL="brew install gcc@5 opencv@3 && CC=gcc-5 && CXX=g++-5 && OpenCV_DIR=/usr/local/opt/opencv@3"
-
-    - os: osx
-      compiler: gcc
       name: macOS - native gcc (llvm backend) - opencv@2
       env:
         - MATRIX_EVAL="brew install opencv@2 && OpenCV_DIR=/usr/local/opt/opencv@2"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,13 +32,10 @@ install:
   - cd %WORKSPACE%\
   - if [%USE_CUDA%]==[yes] curl -L https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.105_418.96_win10.exe -o setup.exe
   - if [%USE_CUDA%]==[yes] .\setup.exe -s nvcc_10.1 cuobjdump_10.1 nvprune_10.1 cupti_10.1 gpu_library_advisor_10.1 memcheck_10.1 nvdisasm_10.1 nvprof_10.1 visual_profiler_10.1 visual_studio_integration_10.1 cublas_10.1 cublas_dev_10.1 cudart_10.1 cufft_10.1 cufft_dev_10.1 curand_10.1 curand_dev_10.1 cusolver_10.1 cusolver_dev_10.1 cusparse_10.1 cusparse_dev_10.1 nvgraph_10.1 nvgraph_dev_10.1 npp_10.1 npp_dev_10.1 nvrtc_10.1 nvrtc_dev_10.1 nvml_dev_10.1 occupancy_calculator_10.1 fortran_examples_10.1
-  - if [%USE_CUDA%]==[yes] set CUDACXX=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.1\bin
-  - if [%USE_CUDA%]==[yes] set CMAKE_CUDA_COMPILER=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.1\bin
-  - if [%USE_CUDA%]==[yes] set CUDA_TOOLKIT_ROOT_DIR=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.1
   - if [%USE_CUDA%]==[yes] set CUDA_PATH=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.1
-  - if [%USE_CUDA%]==[yes] set CUDA_PATH_V10_1=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.1
-  - if [%USE_CUDA%]==[yes] set PATH=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.1\nvvm\bin;%PATH%
-  - if [%USE_CUDA%]==[yes] set PATH=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.1\bin;%PATH%
+  - if [%USE_CUDA%]==[yes] set CUDA_PATH_V10_1=%CUDA_PATH%
+  - if [%USE_CUDA%]==[yes] set CUDA_TOOLKIT_ROOT_DIR=%CUDA_PATH%
+  - if [%USE_CUDA%]==[yes] set PATH=%CUDA_PATH%\bin;%PATH%
   - cd %WORKSPACE%\
   - mkdir cygwin-downloads
   - ps: if($env:COMPILER -eq "cygwin") { Invoke-WebRequest https://cygwin.com/setup-x86_64.exe -OutFile $env:WORKSPACE\cygwin-setup.exe }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,17 @@ install:
   - cd ..
 
 build_script:
-  - if [%COMPILER%]==[cygwin]                                   cd build_debug   && %CYGSH% 'cmake --build .'        && cd ..
-  - if [%COMPILER%]==[cygwin]                                   cd build_release && %CYGSH% 'cmake --build .'        && cd ..
-  - if [%COMPILER%]==[vs] if NOT [%USE_INTEGRATED_LIBS%]==[yes] cd build_debug   && cmake --build . --config Debug   && cd ..
-  - if [%COMPILER%]==[vs]                                       cd build_release && cmake --build . --config Release && cd ..
+  - if [%COMPILER%]==[cygwin]                                   cd build_debug   && %CYGSH% 'cmake --build . --target install'        && cd ..
+  - if [%COMPILER%]==[cygwin]                                   cd build_release && %CYGSH% 'cmake --build . --target install'        && cd ..
+  - if [%COMPILER%]==[vs] if NOT [%USE_INTEGRATED_LIBS%]==[yes] cd build_debug   && cmake --build . --config Debug --target install   && cd ..
+  - if [%COMPILER%]==[vs]                                       cd build_release && cmake --build . --config Release --target install && cd ..
+
+artifacts:
+  - path: './darklib.lib'
+    name: darklib.lib
+  - path: './darklib.dll'
+    name: darklib.dll
+  - path: './uselib.exe'
+    name: uselib.exe
+  - path: './darknet.exe'
+    name: darknet.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,6 @@ environment:
       VCPKG_ROOT: C:\projects\vcpkg
       VCPKG_DEFAULT_TRIPLET: x64-windows
       USE_CUDA: yes
-      CUDACXX: C:\CUDA\bin\nvcc.exe
-      CUDA_PATH: C:\CUDA\
-      CUDA_PATH_V10_0: C:\CUDA\
     - platform: Win64
       COMPILER: vs
       VCPKG_ROOT: C:\projects\vcpkg
@@ -33,12 +30,15 @@ install:
   - if [%COMPILER%]==[cygwin] SET PATH=%PATH:C:\Program Files\Git\usr\bin;=%
   - git submodule -q update --init --recursive
   - cd %WORKSPACE%\
-  - if [%USE_CUDA%]==[yes] curl -L https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/cuda_10.0.130_411.31_windows -o cuda_10.0.130_411.31_windows.exe
-  - if [%USE_CUDA%]==[yes] mkdir C:\CUDATEMP
-  - if [%USE_CUDA%]==[yes] mkdir C:\CUDA
-  - if [%USE_CUDA%]==[yes] 7z x cuda_10.0.130_411.31_windows.exe -oC:\CUDATEMP
-  - if [%USE_CUDA%]==[yes] cd C:\CUDATEMP
-  - if [%USE_CUDA%]==[yes] FOR /D %%G in ("*") DO xcopy C:\CUDATEMP\%%G\* C:\CUDA\ /s /y
+  - if [%USE_CUDA%]==[yes] curl -L https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/cuda_10.1.105_418.96_win10.exe -o setup.exe
+  - if [%USE_CUDA%]==[yes] .\setup.exe -s nvcc_10.1 cuobjdump_10.1 nvprune_10.1 cupti_10.1 gpu_library_advisor_10.1 memcheck_10.1 nvdisasm_10.1 nvprof_10.1 visual_profiler_10.1 visual_studio_integration_10.1 cublas_10.1 cublas_dev_10.1 cudart_10.1 cufft_10.1 cufft_dev_10.1 curand_10.1 curand_dev_10.1 cusolver_10.1 cusolver_dev_10.1 cusparse_10.1 cusparse_dev_10.1 nvgraph_10.1 nvgraph_dev_10.1 npp_10.1 npp_dev_10.1 nvrtc_10.1 nvrtc_dev_10.1 nvml_dev_10.1 occupancy_calculator_10.1 fortran_examples_10.1
+  - if [%USE_CUDA%]==[yes] set CUDACXX=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.1\bin
+  - if [%USE_CUDA%]==[yes] set CMAKE_CUDA_COMPILER=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.1\bin
+  - if [%USE_CUDA%]==[yes] set CUDA_TOOLKIT_ROOT_DIR=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.1
+  - if [%USE_CUDA%]==[yes] set CUDA_PATH=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.1
+  - if [%USE_CUDA%]==[yes] set CUDA_PATH_V10_1=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.1
+  - if [%USE_CUDA%]==[yes] set PATH=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.1\nvvm\bin;%PATH%
+  - if [%USE_CUDA%]==[yes] set PATH=%ProgramFiles%\NVIDIA GPU Computing Toolkit\CUDA\v10.1\bin;%PATH%
   - cd %WORKSPACE%\
   - mkdir cygwin-downloads
   - ps: if($env:COMPILER -eq "cygwin") { Invoke-WebRequest https://cygwin.com/setup-x86_64.exe -OutFile $env:WORKSPACE\cygwin-setup.exe }

--- a/build.ps1
+++ b/build.ps1
@@ -47,6 +47,22 @@ if ($null -eq (Get-Command "cl.exe" -ErrorAction SilentlyContinue)) {
   Write-Host "Visual Studio 2017 ${vstype} Command Prompt variables set.`n" -ForegroundColor Yellow
 }
 
+if ($null -eq (Get-Command "nvcc.exe" -ErrorAction SilentlyContinue)) {
+  if (Test-Path env:CUDA_PATH) {
+    $env:PATH += ";${env:CUDA_PATH}\bin"
+  }
+  else {
+    Write-Host "Unable to find CUDA, if necessary please install it or define a CUDA_PATH env variable pointing to the install folder`n" -ForegroundColor Yellow
+  }
+}
+
+if (Test-Path env:CUDA_PATH) {
+  if (-Not(Test-Path env:CUDA_TOOLKIT_ROOT_DIR)) {
+    $env:CUDA_TOOLKIT_ROOT_DIR = "${env:CUDA_PATH}"
+    Write-Host "Added missing env variable CUDA_TOOLKIT_ROOT_DIR`n" -ForegroundColor Yellow
+  }
+}
+
 if (Test-Path $vcpkg_path) {
   # RELEASE
   New-Item -Path .\build_win_release -ItemType directory -Force

--- a/build.ps1
+++ b/build.ps1
@@ -48,18 +48,18 @@ if ($null -eq (Get-Command "cl.exe" -ErrorAction SilentlyContinue)) {
 }
 
 if (Test-Path $vcpkg_path) {
-  # DEBUG
-  New-Item -Path .\build_win_debug -ItemType directory -Force
-  Set-Location build_win_debug
-  cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" "-DCMAKE_TOOLCHAIN_FILE=$vcpkg_path\scripts\buildsystems\vcpkg.cmake" "-DVCPKG_TARGET_TRIPLET=$vcpkg_triplet" "-DCMAKE_BUILD_TYPE=Debug" $shared_lib ..
-  cmake --build . --config Debug --parallel ${number_of_build_workers} --target install
-  Set-Location ..
-
   # RELEASE
   New-Item -Path .\build_win_release -ItemType directory -Force
   Set-Location build_win_release
   cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" "-DCMAKE_TOOLCHAIN_FILE=$vcpkg_path\scripts\buildsystems\vcpkg.cmake" "-DVCPKG_TARGET_TRIPLET=$vcpkg_triplet" "-DCMAKE_BUILD_TYPE=Release" $shared_lib ..
   cmake --build . --config Release --parallel ${number_of_build_workers} --target install
+  Set-Location ..
+
+  # DEBUG
+  New-Item -Path .\build_win_debug -ItemType directory -Force
+  Set-Location build_win_debug
+  cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" "-DCMAKE_TOOLCHAIN_FILE=$vcpkg_path\scripts\buildsystems\vcpkg.cmake" "-DVCPKG_TARGET_TRIPLET=$vcpkg_triplet" "-DCMAKE_BUILD_TYPE=Debug" $shared_lib ..
+  cmake --build . --config Debug --parallel ${number_of_build_workers} --target install
   Set-Location ..
 }
 else {

--- a/build.ps1
+++ b/build.ps1
@@ -1,43 +1,73 @@
 #!/usr/bin/env pwsh
 
 $number_of_build_workers=8
-$vstype="Community"
+#$shared_lib="-DBUILD_SHARED_LIBS:BOOL=ON"
 
-if ((Get-Command "cl.exe" -ErrorAction SilentlyContinue) -eq $null)
-{
-  pushd "C:\Program Files (x86)\Microsoft Visual Studio\2017\${vstype}\Common7\Tools"
+if (Test-Path env:VCPKG_ROOT) {
+  $vcpkg_path = "$env:VCPKG_ROOT"
+  Write-Host "Found vcpkg in VCPKG_ROOT: $vcpkg_path"
+}
+elseif (Test-Path "${env:WORKSPACE}\vcpkg") {
+  $vcpkg_path = "${env:WORKSPACE}\vcpkg"
+  Write-Host "Found vcpkg in WORKSPACE\vcpkg: $vcpkg_path"
+}
+else {
+  Write-Host "Skipping vcpkg-enabled builds because the VCPKG_ROOT environment variable is not defined, using self-distributed libs`n" -ForegroundColor Yellow
+}
+
+if ($null -eq $env:VCPKG_DEFAULT_TRIPLET) {
+  Write-Host "No default triplet has been set-up for vcpkg. Defaulting to x64-windows`n" -ForegroundColor Yellow
+  $vcpkg_triplet = "x64-windows"
+}
+else {
+  $vcpkg_triplet = $env:VCPKG_DEFAULT_TRIPLET
+}
+
+if ($vcpkg_triplet -Match "x86") {
+  Throw "darknet is supported only in x64 builds!"
+}
+
+if ($null -eq (Get-Command "cl.exe" -ErrorAction SilentlyContinue)) {
+  $vstype = "Professional"
+  if (Test-Path "C:\Program Files (x86)\Microsoft Visual Studio\2017\${vstype}\Common7\Tools") {
+    Write-Host "Found VS 2017 Professional"
+  }
+  else {
+    $vstype = "Community"
+    Write-Host "Found VS 2017 Community"
+  }
+  Push-Location "C:\Program Files (x86)\Microsoft Visual Studio\2017\${vstype}\Common7\Tools"
   cmd /c "VsDevCmd.bat -arch=x64 & set" |
-    foreach {
+    ForEach-Object {
     if ($_ -match "=") {
       $v = $_.split("="); set-item -force -path "ENV:\$($v[0])"  -value "$($v[1])"
     }
   }
-  popd
+  Pop-Location
   Write-Host "Visual Studio 2017 ${vstype} Command Prompt variables set.`n" -ForegroundColor Yellow
 }
 
-if (Test-Path env:VCPKG_ROOT) {
+if (Test-Path $vcpkg_path) {
   # DEBUG
   New-Item -Path .\build_win_debug -ItemType directory -Force
   Set-Location build_win_debug
-  cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" "-DVCPKG_TARGET_TRIPLET=$env:VCPKG_DEFAULT_TRIPLET"   "-DCMAKE_BUILD_TYPE=Debug" ..
-  cmake --build . --config Debug --parallel ${number_of_build_workers}
+  cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" "-DCMAKE_TOOLCHAIN_FILE=$vcpkg_path\scripts\buildsystems\vcpkg.cmake" "-DVCPKG_TARGET_TRIPLET=$vcpkg_triplet" "-DCMAKE_BUILD_TYPE=Debug" $shared_lib ..
+  cmake --build . --config Debug --parallel ${number_of_build_workers} --target install
   Set-Location ..
 
   # RELEASE
   New-Item -Path .\build_win_release -ItemType directory -Force
   Set-Location build_win_release
-  cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" "-DVCPKG_TARGET_TRIPLET=$env:VCPKG_DEFAULT_TRIPLET"   "-DCMAKE_BUILD_TYPE=Release" ..
-  cmake --build . --config Release --parallel ${number_of_build_workers}
+  cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" "-DCMAKE_TOOLCHAIN_FILE=$vcpkg_path\scripts\buildsystems\vcpkg.cmake" "-DVCPKG_TARGET_TRIPLET=$vcpkg_triplet" "-DCMAKE_BUILD_TYPE=Release" $shared_lib ..
+  cmake --build . --config Release --parallel ${number_of_build_workers} --target install
   Set-Location ..
 }
 else {
-  Write-Host "Skipping vcpkg-enabled builds because the VCPKG_ROOT environment variable is not defined`n" -ForegroundColor Yellow
+  # USE LOCAL PTHREAD LIB, NO VCPKG, ONLY RELEASE
+  # if you want to manually force this case, remove VCPKG_ROOT env variable and remember to use "vcpkg integrate remove" in case you had enabled user-wide vcpkg integration
+  New-Item -Path .\build_win_release_novcpkg -ItemType directory -Force
+  Set-Location build_win_release_novcpkg
+  cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" $shared_lib ..
+  cmake --build . --config Release --parallel ${number_of_build_workers} --target install
+  Set-Location ..
 }
-
-# USE LOCAL PTHREAD LIB, NO VCPKG: remember to use "vcpkg.exe integrate remove" in case you had enable user-wide vcpkg integration
-New-Item -Path .\build_win_release_cuda_int_libs -ItemType directory -Force
-Set-Location build_win_release_cuda_int_libs
-cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" ..
-cmake --build . --config Release --parallel ${number_of_build_workers}
-Set-Location ..

--- a/build.sh
+++ b/build.sh
@@ -2,18 +2,18 @@
 
 number_of_build_workers=8
 
-# DEBUG
-mkdir -p build_debug
-cd build_debug
-cmake .. -DCMAKE_BUILD_TYPE=Debug
-cmake --build . --target install -- -j${number_of_build_workers}
-#cmake --build . --target install --parallel ${number_of_build_workers}  #valid only for CMake 3.12+
-cd ..
-
 # RELEASE
 mkdir -p build_release
 cd build_release
 cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake --build . --target install -- -j${number_of_build_workers}
+#cmake --build . --target install --parallel ${number_of_build_workers}  #valid only for CMake 3.12+
+cd ..
+
+# DEBUG
+mkdir -p build_debug
+cd build_debug
+cmake .. -DCMAKE_BUILD_TYPE=Debug
 cmake --build . --target install -- -j${number_of_build_workers}
 #cmake --build . --target install --parallel ${number_of_build_workers}  #valid only for CMake 3.12+
 cd ..

--- a/build.sh
+++ b/build.sh
@@ -2,13 +2,6 @@
 
 number_of_build_workers=8
 
-if [[ "$OSTYPE" == "darwin"* && "$1" == "gcc" ]]; then
-  export CC="/usr/local/bin/gcc-8"
-  export CXX="/usr/local/bin/g++-8"
-fi
-
-rm -f uselib darknet
-
 # DEBUG
 mkdir -p build_debug
 cd build_debug


### PR DESCRIPTION
I noticed that CUDA was not really built on Windows with the latest revision, this should just make sure that CUDA is really installed and tested.
I also removed the gcc@5 build on macOS, because of the error explained in here: https://github.com/AlexeyAB/darknet/pull/2476
Unfortunately any gcc newer than that was already unsupported, and it seems that on newer OpenCV@3 builds also that gcc went broken. `brew` just went crazy removing all flags for default packages (https://github.com/Homebrew/homebrew-core/issues/31510) but this became in a real mess for me in many works, because it is now impossible to ask for packages with special options or linked with a different stdlib. In this case, the real problem is in fact rooted to a discrepancy between `libc++` and `libstdc++` (clang vs gcc).
Instead of fighting with an old compiler and an old toolchain, I think it's easier to just remove it and completely declare it unsupported.