### PR TITLE
improve darknet library handling for downstream projects, other small updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.out
 *.png
 *.so
+*.exe
 mnist/
 data/
 caffe/
@@ -15,8 +16,10 @@ decaf/
 submission/
 cfg/
 build/darknet/*
+build_*/
 !build/darknet/YoloWrapper.cs
 .fuse*
+*.weights
 
 # OS Generated #
 .DS_Store*
@@ -24,3 +27,8 @@ ehthumbs.db
 Icon?
 Thumbs.db
 *.swp
+
+lib/
+include/
+share/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -410,5 +410,5 @@ before_script:
   - cd ..
 
 script:
-  - cd build_debug && cmake --build . --target install && cd ..
-  - cd build_release && cmake --build . --target install && cd ..
+  - cd build_debug   && cmake --build . --target install -- -j8 && cd ..
+  - cd build_release && cmake --build . --target install -- -j8 && cd ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,17 @@
-# To use your libs, launch cmake with -DUSE_INTEGRATED_LIBS:BOOL=FALSE
-
 cmake_minimum_required(VERSION 3.4)
 
-#set(CMAKE_VERBOSE_MAKEFILE 1)
+set(Darknet_MAJOR_VERSION 1)
+set(Darknet_MINOR_VERSION 0)
+set(Darknet_PATCH_VERSION 0)
+set(Darknet_VERSION ${Darknet_MAJOR_VERSION}.${Darknet_MINOR_VERSION}.${Darknet_PATCH_VERSION})
+
+set(CMAKE_VERBOSE_MAKEFILE "FALSE" CACHE BOOL "Create verbose makefile")
 
 if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   set(CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" CACHE STRING "")
 endif()
 
-project(darknet)
+project(Darknet VERSION ${Darknet_VERSION})
 
 if(WIN32 AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   set(USE_INTEGRATED_LIBS "TRUE" CACHE BOOL "Use libs distributed with this repo")
@@ -21,10 +24,20 @@ enable_language(CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/" ${CMAKE_MODULE_PATH})
-include_directories(${CMAKE_CURRENT_LIST_DIR}/include)
-include_directories(${CMAKE_CURRENT_LIST_DIR}/src)
 
-set(SKIP_USELIB_TRACK "FALSE" CACHE BOOL "Skip building uselib_track" FORCE)
+set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Install prefix" FORCE)
+set(INSTALL_BIN_DIR      "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "Path where exe and dll will be installed" FORCE)
+set(INSTALL_LIB_DIR      "lib"                       CACHE PATH "Path where lib will be installed")
+set(INSTALL_INCLUDE_DIR  "include"                   CACHE PATH "Path where headers will be installed")
+set(INSTALL_CMAKE_DIR    "share/darknet"             CACHE PATH "Path where cmake configs will be installed")
+# Make relative paths absolute (needed later on)
+foreach(p LIB BIN INCLUDE CMAKE)
+  set(var INSTALL_${p}_DIR)
+  if(NOT IS_ABSOLUTE "${${var}}")
+    set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
+  endif()
+endforeach()
+
 set(ENABLE_CUDA "TRUE" CACHE BOOL "Enable CUDA build")
 if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
   set(ENABLE_CUDA "FALSE" CACHE BOOL "Enable CUDA build" FORCE)
@@ -61,17 +74,12 @@ endif()
 
 if(USE_INTEGRATED_LIBS)
   include_directories(${CMAKE_CURRENT_LIST_DIR}/3rdparty/include)
-  set(PTHREADS_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/3rdparty/include)
-  set(PTHREADS_LIBRARY ${CMAKE_CURRENT_LIST_DIR}/3rdparty/lib/x64/pthreadVC2.lib)
+  set(PThreads_windows_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/3rdparty/include)
+  set(PThreads_windows_LIBRARY ${CMAKE_CURRENT_LIST_DIR}/3rdparty/lib/x64/pthreadVC2.lib)
   add_definitions(-D_TIMESPEC_DEFINED)
 endif()
 
-if(NOT APPLE)
-  set(CMAKE_SKIP_BUILD_RPATH  FALSE)
-  set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-endif()
-set(CMAKE_INSTALL_RPATH "${CMAKE_SOURCE_DIR}")
+set(CMAKE_DEBUG_POSTFIX d)
 
 add_definitions(-DUSE_CMAKE_LIBS)
 
@@ -96,19 +104,18 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   string(REGEX REPLACE "-O3" "-Ofast" CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE})
 endif()
 
-if(APPLE)
-  find_package(OpenCV PATHS "/usr/local/Cellar/opencv@3/3.4.5" NO_DEFAULT_PATH)
-else()
+set(ENABLE_OPENCV "TRUE" CACHE BOOL "Enable OpenCV integration")
+if(ENABLE_OPENCV)
   find_package(OpenCV)
 endif()
 
+set(SKIP_USELIB_TRACK "FALSE" CACHE BOOL "Skip building uselib_track" FORCE)
 if(OpenCV_FOUND)
   if(ENABLE_CUDA AND NOT OpenCV_CUDA_VERSION)
     set(SKIP_USELIB_TRACK "TRUE" CACHE BOOL "Skip building uselib_track" FORCE)
     message(WARNING "The build of OpenCV does not have CUDA support, so some tools have been disabled! Please rebuild OpenCV with CUDA support to build them!")
   endif()
   add_definitions(-DOPENCV)
-  include_directories(${OpenCV_INCLUDE_DIRS})
 endif()
 
 if(ENABLE_CUDA)
@@ -124,7 +131,6 @@ if(ENABLE_CUDA)
   find_package(CUDNN)
   if(CUDNN_FOUND)
     add_definitions(-DCUDNN)
-    include_directories(${CUDNN_INCLUDE_DIR})
     if(CUDA_COMPUTE_MODEL VERSION_GREATER_EQUAL ${CUDA_COMPUTE_MODEL_70})
       add_definitions(-DCUDNN_HALF)
       message(STATUS "Enabled CUDNN_HALF")
@@ -165,7 +171,6 @@ set(CMAKE_THREAD_PREFER_PTHREAD ON)
 find_package(Threads REQUIRED)
 if(MSVC)
   find_package(PThreads_windows REQUIRED)
-  include_directories(${PTHREADS_INCLUDE_DIR})
 endif()
 
 if(${CMAKE_VERSION} VERSION_LESS "3.9.0")
@@ -180,7 +185,7 @@ endif()
 #look for all *.h files in src folder
 file(GLOB headers "${CMAKE_CURRENT_LIST_DIR}/src/*.h")
 #add also files in the include folder
-list(APPEND sources
+list(APPEND headers
   ${CMAKE_CURRENT_LIST_DIR}/include/darknet.h
 )
 #remove windows only files, will be re-added if necessary later
@@ -188,6 +193,7 @@ list(REMOVE_ITEM headers
   ${CMAKE_CURRENT_LIST_DIR}/src/gettimeofday.h
   ${CMAKE_CURRENT_LIST_DIR}/src/getopt.h
 )
+set(exported_headers ${headers})
 
 #look for all *.c files in src folder
 file(GLOB sources "${CMAKE_CURRENT_LIST_DIR}/src/*.c")
@@ -223,7 +229,7 @@ endif()
 
 set_source_files_properties(${sources} PROPERTIES LANGUAGE CXX)
 
-add_library(darklib SHARED ${CMAKE_CURRENT_LIST_DIR}/include/yolo_v2_class.hpp ${CMAKE_CURRENT_LIST_DIR}/src/yolo_v2_class.cpp ${sources} ${headers} ${cuda_sources})
+add_library(darklib ${CMAKE_CURRENT_LIST_DIR}/include/yolo_v2_class.hpp ${CMAKE_CURRENT_LIST_DIR}/src/yolo_v2_class.cpp ${sources} ${headers} ${cuda_sources})
 set_target_properties(darklib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if(ENABLE_CUDA)
   set_target_properties(darklib PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
@@ -235,6 +241,8 @@ if(OpenCV_VERSION VERSION_GREATER "3.0" AND NOT SKIP_USELIB_TRACK)
   add_executable(uselib_track ${CMAKE_CURRENT_LIST_DIR}/src/yolo_console_dll.cpp)
   target_compile_definitions(uselib_track PRIVATE TRACK_OPTFLOW=1)
   set_target_properties(uselib_track PROPERTIES LINKER_LANGUAGE CXX)
+  target_include_directories(uselib_track PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src> $<INSTALL_INTERFACE:include>)
+  target_link_libraries(uselib_track PRIVATE ${OpenCV_LIBS})
 endif()
 
 add_executable(uselib ${CMAKE_CURRENT_LIST_DIR}/src/yolo_console_dll.cpp)
@@ -244,45 +252,97 @@ add_executable(darknet ${CMAKE_CURRENT_LIST_DIR}/src/darknet.c ${sources} ${head
 set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/src/darknet.c PROPERTIES LANGUAGE CXX)
 set_target_properties(darknet PROPERTIES LINKER_LANGUAGE CXX)
 
+target_include_directories(darknet PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src> $<INSTALL_INTERFACE:include>)
+target_include_directories(darklib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src> $<INSTALL_INTERFACE:include>)
+target_include_directories(uselib PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include> $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src> $<INSTALL_INTERFACE:include>)
+
 if(CUDNN_FOUND)
-  target_link_libraries(darknet ${CUDNN_LIBRARY})
-  target_link_libraries(darklib ${CUDNN_LIBRARY})
+  target_link_libraries(darknet PRIVATE CuDNN::CuDNN)
+  target_link_libraries(darklib PRIVATE CuDNN::CuDNN)
 endif()
 
 if(OpenCV_FOUND)
-  target_link_libraries(darknet ${OpenCV_LIBS})
-  target_link_libraries(darklib ${OpenCV_LIBS})
+  target_link_libraries(darknet PRIVATE ${OpenCV_LIBS})
+  target_link_libraries(uselib PRIVATE ${OpenCV_LIBS})
+  target_link_libraries(darklib PRIVATE ${OpenCV_LIBS})
 endif()
 
 if(OPENMP_FOUND)
-  target_link_libraries(darknet OpenMP::OpenMP_CXX)
-  target_link_libraries(darklib OpenMP::OpenMP_CXX)
+  target_link_libraries(darknet PRIVATE OpenMP::OpenMP_CXX)
+  target_link_libraries(darklib PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC)
-  target_link_libraries(darknet m)
-  target_link_libraries(darklib m)
+  target_link_libraries(darknet PRIVATE m)
+  target_link_libraries(darklib PRIVATE m)
 endif()
 
 if(MSVC)
-  target_link_libraries(darknet ${PTHREADS_LIBRARY})
-  target_link_libraries(darknet wsock32 ws2_32)
-  target_link_libraries(darklib ${PTHREADS_LIBRARY})
-  target_link_libraries(darklib wsock32 ws2_32)
+  target_link_libraries(darknet PRIVATE PThreads_windows::PThreads_windows)
+  target_link_libraries(darknet PRIVATE wsock32 ws2_32)
+  target_link_libraries(darklib PRIVATE PThreads_windows::PThreads_windows)
+  target_link_libraries(darklib PRIVATE wsock32 ws2_32)
 endif()
 
-target_link_libraries(darknet Threads::Threads)
-target_link_libraries(darklib Threads::Threads)
+target_link_libraries(darknet PRIVATE Threads::Threads)
+target_link_libraries(darklib PRIVATE Threads::Threads)
 
 if(ENABLE_CUDA)
-  target_link_libraries(darknet curand cublas)
-  target_link_libraries(darklib curand cublas)
+  target_link_libraries(darknet PRIVATE curand cublas)
+  target_link_libraries(darklib PRIVATE curand cublas)
+  set_target_properties(darklib PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 endif()
 
-target_link_libraries(uselib darklib)
+target_link_libraries(uselib PRIVATE darklib)
 if(OpenCV_VERSION VERSION_GREATER "3.0" AND NOT SKIP_USELIB_TRACK)
-  target_link_libraries(uselib_track darklib)
-  install(TARGETS uselib_track DESTINATION ${CMAKE_SOURCE_DIR}/)
+  target_link_libraries(uselib_track PRIVATE darklib)
 endif()
 
-install(TARGETS darklib uselib darknet DESTINATION ${CMAKE_SOURCE_DIR}/)
+set_target_properties(darklib PROPERTIES PUBLIC_HEADER "${exported_headers};${CMAKE_CURRENT_LIST_DIR}/include/yolo_v2_class.hpp")
+
+install(TARGETS darklib uselib darknet EXPORT DarknetTargets
+  RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
+  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
+  PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDE_DIR}"
+  COMPONENT dev
+)
+if(OpenCV_VERSION VERSION_GREATER "3.0" AND NOT SKIP_USELIB_TRACK)
+  install(TARGETS uselib_track
+    EXPORT DarknetTargets
+    RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
+    LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+    ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
+    PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDE_DIR}"
+    COMPONENT dev
+  )
+endif()
+
+install(EXPORT DarknetTargets
+  FILE DarknetTargets.cmake
+  NAMESPACE Darknet::
+  DESTINATION "${INSTALL_CMAKE_DIR}"
+)
+
+# Export the package for use from the build-tree (this registers the build-tree with a global CMake-registry)
+export(PACKAGE Darknet)
+
+# Create the DarknetConfig.cmake
+# First of all we compute the relative path between the cmake config file and the include path
+file(RELATIVE_PATH REL_INCLUDE_DIR "${INSTALL_CMAKE_DIR}" "${INSTALL_INCLUDE_DIR}")
+set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}" "${PROJECT_BINARY_DIR}")
+configure_file(DarknetConfig.cmake.in "${PROJECT_BINARY_DIR}/DarknetConfig.cmake" @ONLY)
+set(CONF_INCLUDE_DIRS "\${Darknet_CMAKE_DIR}/${REL_INCLUDE_DIR}")
+configure_file(DarknetConfig.cmake.in "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/DarknetConfig.cmake" @ONLY)
+
+# Create the DarknetConfigVersion.cmake
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("${PROJECT_BINARY_DIR}/DarknetConfigVersion.cmake"
+  COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/DarknetConfig.cmake"
+  "${PROJECT_BINARY_DIR}/DarknetConfigVersion.cmake"
+  DESTINATION "${INSTALL_CMAKE_DIR}"
+)

--- a/DarknetConfig.cmake.in
+++ b/DarknetConfig.cmake.in
@@ -1,0 +1,33 @@
+# Config file for the Darknet package
+# It defines the following variables
+#  Darknet_INCLUDE_DIRS - include directories for Darknet
+#  Darknet_LIBRARIES    - libraries to link against
+
+# Compute paths
+get_filename_component(Darknet_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+set(Darknet_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(OpenCV REQUIRED)
+
+if(@ENABLE_CUDA@)
+  find_dependency(CUDNN)
+endif()
+
+set(CMAKE_THREAD_PREFER_PTHREAD ON)
+find_dependency(Threads)
+
+if(@MSVC@)
+  find_dependency(PThreads_windows)
+endif()
+
+if("@CMAKE_VERSION@" VERSION_GREATER "3.9.0")
+  find_dependency(OpenMP)
+endif()
+
+# Our library dependencies (contains definitions for IMPORTED targets)
+include("${Darknet_CMAKE_DIR}/DarknetTargets.cmake")
+
+# These are IMPORTED targets created by DarknetTargets.cmake
+set(Darknet_LIBRARIES darklib)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,16 +10,31 @@ environment:
       CYGSH: C:\cygwin64\bin\bash -c
     - platform: Win64
       COMPILER: vs
+      configuration: Release
       VCPKG_ROOT: C:\projects\vcpkg
       VCPKG_DEFAULT_TRIPLET: x64-windows
       USE_CUDA: yes
     - platform: Win64
       COMPILER: vs
+      configuration: Debug
+      VCPKG_ROOT: C:\projects\vcpkg
+      VCPKG_DEFAULT_TRIPLET: x64-windows
+      USE_CUDA: yes
+    - platform: Win64
+      COMPILER: vs
+      configuration: Release
       VCPKG_ROOT: C:\projects\vcpkg
       VCPKG_DEFAULT_TRIPLET: x64-windows
       USE_CUDA: no
     - platform: Win64
       COMPILER: vs
+      configuration: Debug
+      VCPKG_ROOT: C:\projects\vcpkg
+      VCPKG_DEFAULT_TRIPLET: x64-windows
+      USE_CUDA: no
+    - platform: Win64
+      COMPILER: vs
+      configuration: Release
       USE_INTEGRATED_LIBS: yes
 
 install:
@@ -49,26 +64,20 @@ install:
   - cd %WORKSPACE%\darknet\
   - mkdir build_debug && cd build_debug
   - if [%COMPILER%]==[cygwin] %CYGSH% 'cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE="Debug"'
-  - if [%COMPILER%]==[vs] if NOT [%USE_INTEGRATED_LIBS%]==[yes] cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" "-DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake" "-DVCPKG_TARGET_TRIPLET=%VCPKG_DEFAULT_TRIPLET%" -DCMAKE_BUILD_TYPE="Debug" ..
+  - if [%COMPILER%]==[vs] if NOT [%USE_INTEGRATED_LIBS%]==[yes] if [%configuration%]==[Debug] cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" "-DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake" "-DVCPKG_TARGET_TRIPLET=%VCPKG_DEFAULT_TRIPLET%" -DCMAKE_BUILD_TYPE="Debug" ..
   - cd ..
   - mkdir build_release && cd build_release
   - if [%COMPILER%]==[cygwin] %CYGSH% 'cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE="Release"'
-  - if [%COMPILER%]==[vs] if NOT [%USE_INTEGRATED_LIBS%]==[yes] cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" "-DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake" "-DVCPKG_TARGET_TRIPLET=%VCPKG_DEFAULT_TRIPLET%" -DCMAKE_BUILD_TYPE="Release" ..
+  - if [%COMPILER%]==[vs] if NOT [%USE_INTEGRATED_LIBS%]==[yes] if [%configuration%]==[Release] cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" "-DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake" "-DVCPKG_TARGET_TRIPLET=%VCPKG_DEFAULT_TRIPLET%" -DCMAKE_BUILD_TYPE="Release" ..
   - if [%COMPILER%]==[vs] if     [%USE_INTEGRATED_LIBS%]==[yes] cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" -DCMAKE_BUILD_TYPE="Release" ..
   - cd ..
 
 build_script:
-  - if [%COMPILER%]==[cygwin]                                   cd build_debug   && %CYGSH% 'cmake --build . --target install -- -j8'              && cd ..
-  - if [%COMPILER%]==[cygwin]                                   cd build_release && %CYGSH% 'cmake --build . --target install -- -j8'              && cd ..
-  - if [%COMPILER%]==[vs] if NOT [%USE_INTEGRATED_LIBS%]==[yes] cd build_debug   && cmake --build . --config Debug --parallel 8 --target install   && cd ..
-  - if [%COMPILER%]==[vs]                                       cd build_release && cmake --build . --config Release --parallel 8 --target install && cd ..
+  - if [%COMPILER%]==[cygwin]                                                                   cd build_debug   && %CYGSH% 'cmake --build . --target install -- -j8'              && cd ..
+  - if [%COMPILER%]==[cygwin]                                                                   cd build_release && %CYGSH% 'cmake --build . --target install -- -j8'              && cd ..
+  - if [%COMPILER%]==[vs] if NOT [%USE_INTEGRATED_LIBS%]==[yes] if [%configuration%]==[Debug]   cd build_debug   && cmake --build . --config Debug --parallel 8 --target install   && cd ..
+  - if [%COMPILER%]==[vs]                                       if [%configuration%]==[Release] cd build_release && cmake --build . --config Release --parallel 8 --target install && cd ..
 
 artifacts:
-  - path: './darklib.lib'
-    name: darklib.lib
-  - path: './darklib.dll'
-    name: darklib.dll
-  - path: './uselib.exe'
-    name: uselib.exe
-  - path: './darknet.exe'
-    name: darknet.exe
+  - path: lib
+  - path: '*.exe'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,10 +58,10 @@ install:
   - cd ..
 
 build_script:
-  - if [%COMPILER%]==[cygwin]                                   cd build_debug   && %CYGSH% 'cmake --build . --target install'        && cd ..
-  - if [%COMPILER%]==[cygwin]                                   cd build_release && %CYGSH% 'cmake --build . --target install'        && cd ..
-  - if [%COMPILER%]==[vs] if NOT [%USE_INTEGRATED_LIBS%]==[yes] cd build_debug   && cmake --build . --config Debug --target install   && cd ..
-  - if [%COMPILER%]==[vs]                                       cd build_release && cmake --build . --config Release --target install && cd ..
+  - if [%COMPILER%]==[cygwin]                                   cd build_debug   && %CYGSH% 'cmake --build . --target install -- -j8'              && cd ..
+  - if [%COMPILER%]==[cygwin]                                   cd build_release && %CYGSH% 'cmake --build . --target install -- -j8'              && cd ..
+  - if [%COMPILER%]==[vs] if NOT [%USE_INTEGRATED_LIBS%]==[yes] cd build_debug   && cmake --build . --config Debug --parallel 8 --target install   && cd ..
+  - if [%COMPILER%]==[vs]                                       cd build_release && cmake --build . --config Release --parallel 8 --target install && cd ..
 
 artifacts:
   - path: './darklib.lib'

--- a/build.ps1
+++ b/build.ps1
@@ -69,14 +69,22 @@ if (Test-Path $vcpkg_path) {
   Set-Location build_win_release
   cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" "-DCMAKE_TOOLCHAIN_FILE=$vcpkg_path\scripts\buildsystems\vcpkg.cmake" "-DVCPKG_TARGET_TRIPLET=$vcpkg_triplet" "-DCMAKE_BUILD_TYPE=Release" $shared_lib ..
   cmake --build . --config Release --parallel ${number_of_build_workers} --target install
+  Remove-Item DarknetConfig.cmake
+  Remove-Item DarknetConfigVersion.cmake
   Set-Location ..
+#  Remove-Item -Force DarknetConfig.cmake
+#  Remove-Item -Force DarknetConfigVersion.cmake
 
   # DEBUG
   New-Item -Path .\build_win_debug -ItemType directory -Force
   Set-Location build_win_debug
   cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" "-DCMAKE_TOOLCHAIN_FILE=$vcpkg_path\scripts\buildsystems\vcpkg.cmake" "-DVCPKG_TARGET_TRIPLET=$vcpkg_triplet" "-DCMAKE_BUILD_TYPE=Debug" $shared_lib ..
   cmake --build . --config Debug --parallel ${number_of_build_workers} --target install
+  Remove-Item DarknetConfig.cmake
+  Remove-Item DarknetConfigVersion.cmake
   Set-Location ..
+#  Remove-Item -Force DarknetConfig.cmake
+#  Remove-Item -Force DarknetConfigVersion.cmake
 }
 else {
   # USE LOCAL PTHREAD LIB, NO VCPKG, ONLY RELEASE
@@ -85,5 +93,9 @@ else {
   Set-Location build_win_release_novcpkg
   cmake -G "Visual Studio 15 2017" -T "host=x64" -A "x64" $shared_lib ..
   cmake --build . --config Release --parallel ${number_of_build_workers} --target install
+  Remove-Item DarknetConfig.cmake
+  Remove-Item DarknetConfigVersion.cmake
   Set-Location ..
+#  Remove-Item -Force DarknetConfig.cmake
+#  Remove-Item -Force DarknetConfigVersion.cmake
 }

--- a/build.sh
+++ b/build.sh
@@ -2,18 +2,36 @@
 
 number_of_build_workers=8
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  OpenCV_DIR="/usr/local/Cellar/opencv@3/3.4.5"
+  additional_defines="-DOpenCV_DIR=${OpenCV_DIR}"
+  if [[ "$1" == "gcc" ]]; then
+    export CC="/usr/local/bin/gcc-8"
+    export CXX="/usr/local/bin/g++-8"
+  fi
+fi
+
+
 # RELEASE
 mkdir -p build_release
 cd build_release
-cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake .. -DCMAKE_BUILD_TYPE=Release ${additional_defines}
 cmake --build . --target install -- -j${number_of_build_workers}
 #cmake --build . --target install --parallel ${number_of_build_workers}  #valid only for CMake 3.12+
+rm DarknetConfig.cmake
+rm DarknetConfigVersion.cmake
 cd ..
+rm DarknetConfig.cmake
+rm DarknetConfigVersion.cmake
 
 # DEBUG
 mkdir -p build_debug
 cd build_debug
-cmake .. -DCMAKE_BUILD_TYPE=Debug
+cmake .. -DCMAKE_BUILD_TYPE=Debug ${additional_defines}
 cmake --build . --target install -- -j${number_of_build_workers}
 #cmake --build . --target install --parallel ${number_of_build_workers}  #valid only for CMake 3.12+
+rm DarknetConfig.cmake
+rm DarknetConfigVersion.cmake
 cd ..
+rm DarknetConfig.cmake
+rm DarknetConfigVersion.cmake

--- a/cmake/Modules/FindDarknet.cmake
+++ b/cmake/Modules/FindDarknet.cmake
@@ -1,0 +1,43 @@
+# Distributed under the OSI-approved BSD 3-Clause License.
+# Copyright Stefano Sinigardi
+
+#.rst:
+# FindDarknet
+# ------------
+#
+# Find the Darknet includes and library.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following variables:
+#
+# ``Darknet_FOUND``
+#   True if Darknet library found
+#
+# ``Darknet_INCLUDE_DIR``
+#   Location of Darknet headers
+#
+# ``Darknet_LIBRARY``
+#   List of libraries to link with when using Darknet
+#
+
+include(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
+include(${CMAKE_ROOT}/Modules/SelectLibraryConfigurations.cmake)
+
+if(NOT Darknet_INCLUDE_DIR)
+  find_path(Darknet_INCLUDE_DIR NAMES darknet.h PATHS darknet darknet/include)
+endif()
+
+# Allow libraries to be set manually
+if(NOT Darknet_LIBRARY)
+  find_library(Darknet_LIBRARY_RELEASE NAMES darklib PATHS darknet darknet/lib)
+  find_library(Darknet_LIBRARY_DEBUG NAMES darklibd PATHS darknet darknet/lib)
+  select_library_configurations(Darknet)
+endif()
+
+set(Darknet_INCLUDE_DIRS "${Darknet_INCLUDE_DIR}")
+set(Darknet_LIBRARIES "${Darknet_LIBRARY}")
+
+find_package_handle_standard_args(Darknet DEFAULT_MSG Darknet_LIBRARY Darknet_INCLUDE_DIR)
+mark_as_advanced(Darknet_INCLUDE_DIR Darknet_INCLUDE_DIRS Darknet_LIBRARY Darknet_LIBRARIES)

--- a/cmake/Modules/FindPThreads_windows.cmake
+++ b/cmake/Modules/FindPThreads_windows.cmake
@@ -31,8 +31,8 @@ endif()
 
 # Allow libraries to be set manually
 if(NOT PThreads_windows_LIBRARY)
-  find_library(PThreads_windows_LIBRARY_RELEASE NAMES pthreadsVC2)
-  find_library(PThreads_windows_LIBRARY_DEBUG NAMES pthreadsVC2d)
+  find_library(PThreads_windows_LIBRARY_RELEASE NAMES pthreadsVC2 pthreadVC2)
+  find_library(PThreads_windows_LIBRARY_DEBUG NAMES pthreadsVC2d pthreadVC2d)
   select_library_configurations(PThreads_windows)
 endif()
 

--- a/cmake/Modules/FindPThreads_windows.cmake
+++ b/cmake/Modules/FindPThreads_windows.cmake
@@ -12,32 +12,32 @@
 #
 # This module defines the following variables:
 #
-# ``PTHREADS_FOUND``
-#   True if PThreads library found
+# ``PThreads_windows_FOUND``
+#   True if PThreads_windows library found
 #
-# ``PTHREADS_INCLUDE_DIR``
-#   Location of PThreads headers
+# ``PThreads_windows_INCLUDE_DIR``
+#   Location of PThreads_windows headers
 #
-# ``PTHREADS_LIBRARY``
-#   List of libraries to link with when using PThreads
+# ``PThreads_windows_LIBRARY``
+#   List of libraries to link with when using PThreads_windows
 #
 
 include(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
 include(${CMAKE_ROOT}/Modules/SelectLibraryConfigurations.cmake)
 
-if(NOT PTHREADS_INCLUDE_DIR)
-  find_path(PTHREADS_INCLUDE_DIR NAMES pthread.h)
+if(NOT PThreads_windows_INCLUDE_DIR)
+  find_path(PThreads_windows_INCLUDE_DIR NAMES pthread.h)
 endif()
 
 # Allow libraries to be set manually
-if(NOT PTHREADS_LIBRARY)
-  find_library(PTHREADS_LIBRARY_RELEASE NAMES pthreadsVC2)
-  find_library(PTHREADS_LIBRARY_DEBUG NAMES pthreadsVC2d)
-  select_library_configurations(PTHREADS)
+if(NOT PThreads_windows_LIBRARY)
+  find_library(PThreads_windows_LIBRARY_RELEASE NAMES pthreadsVC2)
+  find_library(PThreads_windows_LIBRARY_DEBUG NAMES pthreadsVC2d)
+  select_library_configurations(PThreads_windows)
 endif()
 
-find_package_handle_standard_args(PTHREADS DEFAULT_MSG PTHREADS_LIBRARY PTHREADS_INCLUDE_DIR)
-mark_as_advanced(PTHREADS_INCLUDE_DIR PTHREADS_LIBRARY)
+find_package_handle_standard_args(PThreads_windows DEFAULT_MSG PThreads_windows_LIBRARY PThreads_windows_INCLUDE_DIR)
+mark_as_advanced(PThreads_windows_INCLUDE_DIR PThreads_windows_LIBRARY)
 
 
 # Register imported libraries:
@@ -48,30 +48,36 @@ mark_as_advanced(PTHREADS_INCLUDE_DIR PTHREADS_LIBRARY)
 
 # Look for dlls, for Release and Debug libraries.
 if(WIN32)
-  string( REPLACE ".lib" ".dll" PTHREADS_LIBRARY_RELEASE_DLL "${PTHREADS_LIBRARY_RELEASE}" )
-  string( REPLACE ".lib" ".dll" PTHREADS_LIBRARY_DEBUG_DLL   "${PTHREADS_LIBRARY_DEBUG}" )
+  string( REPLACE ".lib" ".dll" PThreads_windows_LIBRARY_RELEASE_DLL "${PThreads_windows_LIBRARY_RELEASE}" )
+  string( REPLACE ".lib" ".dll" PThreads_windows_LIBRARY_DEBUG_DLL   "${PThreads_windows_LIBRARY_DEBUG}" )
 endif()
 
-if( PTHREADS_FOUND AND NOT TARGET PThreads::PThreads )
-  if( EXISTS "${PTHREADS_LIBRARY_RELEASE_DLL}" )
-    add_library( PThreads::PThreads      SHARED IMPORTED )
-    set_target_properties( PThreads::PThreads PROPERTIES
-      IMPORTED_LOCATION_RELEASE         "${PTHREADS_LIBRARY_RELEASE_DLL}"
-      IMPORTED_IMPLIB                   "${PTHREADS_LIBRARY_RELEASE}"
-      INTERFACE_INCLUDE_DIRECTORIES     "${PTHREADS_INCLUDE_DIR}"
+if( PThreads_windows_FOUND AND NOT TARGET PThreads_windows::PThreads_windows )
+  if( EXISTS "${PThreads_windows_LIBRARY_RELEASE_DLL}" )
+    add_library( PThreads_windows::PThreads_windows      SHARED IMPORTED )
+    set_target_properties( PThreads_windows::PThreads_windows PROPERTIES
+      IMPORTED_LOCATION_RELEASE         "${PThreads_windows_LIBRARY_RELEASE_DLL}"
+      IMPORTED_IMPLIB                   "${PThreads_windows_LIBRARY_RELEASE}"
+      INTERFACE_INCLUDE_DIRECTORIES     "${PThreads_windows_INCLUDE_DIR}"
       IMPORTED_CONFIGURATIONS           Release
       IMPORTED_LINK_INTERFACE_LANGUAGES "C" )
-    if( EXISTS "${PTHREADS_LIBRARY_DEBUG_DLL}" )
-      set_property( TARGET PThreads::PThreads APPEND PROPERTY IMPORTED_CONFIGURATIONS Debug )
-      set_target_properties( FFTW::fftw3 PROPERTIES
-        IMPORTED_LOCATION_DEBUG           "${PTHREADS_LIBRARY_DEBUG_DLL}"
-        IMPORTED_IMPLIB_DEBUG             "${PTHREADS_LIBRARY_DEBUG}" )
+    if( EXISTS "${PThreads_windows_LIBRARY_DEBUG_DLL}" )
+      set_property( TARGET PThreads_windows::PThreads_windows APPEND PROPERTY IMPORTED_CONFIGURATIONS Debug )
+      set_target_properties( PThreads_windows::PThreads_windows PROPERTIES
+        IMPORTED_LOCATION_DEBUG           "${PThreads_windows_LIBRARY_DEBUG_DLL}"
+        IMPORTED_IMPLIB_DEBUG             "${PThreads_windows_LIBRARY_DEBUG}" )
     endif()
   else()
-    add_library( PThreads::PThreads      UNKNOWN IMPORTED )
-    set_target_properties( PThreads::PThreads PROPERTIES
-      IMPORTED_LOCATION                 "${PTHREADS_LIBRARY}"
-      INTERFACE_INCLUDE_DIRECTORIES     "${PTHREADS_INCLUDE_DIR}"
+    add_library( PThreads_windows::PThreads_windows      UNKNOWN IMPORTED )
+    set_target_properties( PThreads_windows::PThreads_windows PROPERTIES
+      IMPORTED_LOCATION_RELEASE         "${PThreads_windows_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES     "${PThreads_windows_INCLUDE_DIR}"
+      IMPORTED_CONFIGURATIONS           Release
       IMPORTED_LINK_INTERFACE_LANGUAGES "C" )
+    if( EXISTS "${PThreads_windows_LIBRARY_DEBUG}" )
+      set_property( TARGET PThreads_windows::PThreads_windows APPEND PROPERTY IMPORTED_CONFIGURATIONS Debug )
+      set_target_properties( PThreads_windows::PThreads_windows PROPERTIES
+        IMPORTED_LOCATION_DEBUG           "${PThreads_windows_LIBRARY_DEBUG}" )
+    endif()
   endif()
 endif()

--- a/src/darknet.c
+++ b/src/darknet.c
@@ -1,6 +1,9 @@
 #include <time.h>
 #include <stdlib.h>
 #include <stdio.h>
+#if defined(_MSC_VER) && defined(_DEBUG)
+#include <crtdbg.h>
+#endif
 
 #include "darknet.h"
 #include "parser.h"


### PR DESCRIPTION
In this PR I am preparing the groundwork to enable better integration between `darknet` and a downstream project, using it as a library.
Using the CMake structure already in place, I expanded the target handling and exports, in order to enable an easy `find_package(Darknet)` downstream.
Besides it, I also implemented some tricks to make CI quicker, like splitting the appveyor matrix between debug and release configs, and parallel building whenever possible.
It is not very much tested, so please try it and let me know how is it working for you.
When it will be completed, a `vcpkg` port is ready to be submitted to the official repository (you can try it in my vcpkg fork), to enable "one-click" installation with dependencies and more. 
When this other step will be completed, I will also add to this repository a PowerShell script to install as much as possible from scratch and without user interaction, exploiting the power of `chocolatey` (for executables like `git`, `cmake`, `ninja`, `visual studio`, everything that is installed from a setup.exe) and of `vcpkg` (for libraries, like `pthreads`, `opencv`, `cuda`, but also `darknet` itself, everything that is built from source)