### PR TITLE
Segfault if height > width

### DIFF
--- a/src/classifier.c
+++ b/src/classifier.c
@@ -100,7 +100,7 @@ void train_classifier(char *datacfg, char *cfgfile, char *weightfile, int *gpus,
     args.exposure = net.exposure;
     args.saturation = net.saturation;
     args.hue = net.hue;
-    args.size = net.w;
+    args.size = net.w > net.h ? net.w : net.h;
 
     args.paths = paths;
     args.classes = classes;


### PR DESCRIPTION
```
./darknet classifier train data/sort.data cfg/alexnet.cfg -dont_show
alexnet
1
 compute_capability = 750, cudnn_half = 1 
layer     filters    size              input                output
   0 conv     96 11 x11 / 4   128 x 256 x   3   ->    30 x  62 x  96 0.130 BF
   1 max          3 x 3 / 2    30 x  62 x  96   ->    14 x  30 x  96 0.000 BF
   2 conv    256  5 x 5 / 1    14 x  30 x  96   ->    14 x  30 x 256 0.516 BF
   3 max          3 x 3 / 2    14 x  30 x 256   ->     6 x  14 x 256 0.000 BF
   4 conv    384  3 x 3 / 1     6 x  14 x 256   ->     6 x  14 x 384 0.149 BF
   5 conv    384  3 x 3 / 1     6 x  14 x 384   ->     6 x  14 x 384 0.223 BF
   6 conv    256  3 x 3 / 1     6 x  14 x 384   ->     6 x  14 x 256 0.149 BF
   7 max          3 x 3 / 2     6 x  14 x 256   ->     2 x   6 x 256 0.000 BF
   8 connected                            3072  ->  4096
   9 dropout       p = 0.50               4096  ->  4096
  10 connected                            4096  ->  4096
  11 dropout       p = 0.50               4096  ->  4096
  12 connected                            4096  ->  1261
  13 softmax                                        1261
  14 cost                                           1261
Total BFLOPS 1.167 
 Allocate additional workspace_size = 1940.23 MB 
Learning Rate: 0.01, Momentum: 0.9, Decay: 0.0005
893253
Loaded: 0.205056 seconds
Segmentation fault (core dumped)
```




 This PR fix this issue:
```
./darknet classifier train data/sort.data cfg/alexnet.cfg -dont_show
alexnet
1
 compute_capability = 750, cudnn_half = 1 
layer     filters    size              input                output
   0 conv     96 11 x11 / 4   128 x 256 x   3   ->    30 x  62 x  96 0.130 BF
   1 max          3 x 3 / 2    30 x  62 x  96   ->    14 x  30 x  96 0.000 BF
   2 conv    256  5 x 5 / 1    14 x  30 x  96   ->    14 x  30 x 256 0.516 BF
   3 max          3 x 3 / 2    14 x  30 x 256   ->     6 x  14 x 256 0.000 BF
   4 conv    384  3 x 3 / 1     6 x  14 x 256   ->     6 x  14 x 384 0.149 BF
   5 conv    384  3 x 3 / 1     6 x  14 x 384   ->     6 x  14 x 384 0.223 BF
   6 conv    256  3 x 3 / 1     6 x  14 x 384   ->     6 x  14 x 256 0.149 BF
   7 max          3 x 3 / 2     6 x  14 x 256   ->     2 x   6 x 256 0.000 BF
   8 connected                            3072  ->  4096
   9 dropout       p = 0.50               4096  ->  4096
  10 connected                            4096  ->  4096
  11 dropout       p = 0.50               4096  ->  4096
  12 connected                            4096  ->  1261
  13 softmax                                        1261
  14 cost                                           1261
Total BFLOPS 1.167 
 Allocate additional workspace_size = 1940.23 MB 
Learning Rate: 0.01, Momentum: 0.9, Decay: 0.0005
893253
Loaded: 0.509795 seconds
1, 0.000: 4.070450, 4.070450 avg, 0.010000 rate, 0.310202 seconds, 128 images
Loaded: 0.416345 seconds
2, 0.000: 4.069521, 4.070357 avg, 0.010000 rate, 0.055622 seconds, 256 images
Loaded: 0.451087 seconds
```



I'll tell you later if training is converging.