### PR TITLE
Correctly locate annotation files for tiff images

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -252,6 +252,8 @@ void replace_image_to_label(const char* input_path, char* output_path)
     find_replace_extension(output_path, ".BMP", ".txt", output_path);
     find_replace_extension(output_path, ".ppm", ".txt", output_path);
     find_replace_extension(output_path, ".PPM", ".txt", output_path);
+    find_replace_extension(output_path, ".tiff", ".txt", output_path);
+    find_replace_extension(output_path, ".TIFF", ".txt", output_path);
 }
 
 float sec(clock_t clocks)

--- a/src/utils.c
+++ b/src/utils.c
@@ -255,11 +255,11 @@ void replace_image_to_label(const char* input_path, char* output_path)
     find_replace_extension(output_path, ".tiff", ".txt", output_path);
     find_replace_extension(output_path, ".TIFF", ".txt", output_path);
     
-    // Check file ends with txt and exists:
+    // Check file ends with txt:
     char output_path_ext[3];
     memcpy( output_path_ext, &output_path[strlen(output_path)-3], 3);
     if( strcmp("txt", output_path_ext) != 0){
-        fprintf(stderr, "Failed to find valid annotation file: %s \n", output_path_ext);
+        fprintf(stderr, "Failed to infer label file name (check image extension is supported): %s \n", output_path);
     }
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -256,10 +256,13 @@ void replace_image_to_label(const char* input_path, char* output_path)
     find_replace_extension(output_path, ".TIFF", ".txt", output_path);
     
     // Check file ends with txt:
-    char output_path_ext[3];
-    memcpy( output_path_ext, &output_path[strlen(output_path)-3], 3);
-    if( strcmp("txt", output_path_ext) != 0){
-        fprintf(stderr, "Failed to infer label file name (check image extension is supported): %s \n", output_path);
+    if(strlen(output_path) > 4) {
+        char *output_path_ext = output_path + strlen(output_path) - 4;
+        if( strcmp(".txt", output_path_ext) != 0){
+            fprintf(stderr, "Failed to infer label file name (check image extension is supported): %s \n", output_path);
+        }
+    }else{
+        fprintf(stderr, "Label file name is too short: %s \n", output_path);
     }
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -254,6 +254,13 @@ void replace_image_to_label(const char* input_path, char* output_path)
     find_replace_extension(output_path, ".PPM", ".txt", output_path);
     find_replace_extension(output_path, ".tiff", ".txt", output_path);
     find_replace_extension(output_path, ".TIFF", ".txt", output_path);
+    
+    // Check file ends with txt and exists:
+    char output_path_ext[3];
+    memcpy( output_path_ext, &output_path[strlen(output_path)-3], 3);
+    if( strcmp("txt", output_path_ext) != 0){
+        fprintf(stderr, "Failed to find valid annotation file: %s \n", output_path_ext);
+    }
 }
 
 float sec(clock_t clocks)


### PR DESCRIPTION
This PR adds:

* Support for TIFF images
* Checking that the label file is correctly inferred.

Currently if a non-supported image type is provided (for example tiff), but one that can be opened with e.g. OpenCV, darknet will not correctly replace the extension and it will do this silently. This can result in a fairly subtle bug where training seems to be going OK, loss decreases, but nothing is ever detected. This PR adds a brief message to `stderr` to alert the user.

Probably this function should attempt to replace everything after the last period in the path, rather than relying on a hard-coded list of extensions.