### PR TITLE
No static detector

### DIFF
--- a/build/darknet/YoloWrapper.cs
+++ b/build/darknet/YoloWrapper.cs
@@ -16,7 +16,7 @@ namespace Darknet
 
         [DllImport(YoloLibraryName, EntryPoint = "detect_mat")]
         private static extern int DetectImage(IntPtr pDetector, IntPtr pArray, int nSize, float threshold, ref BboxContainer container);
-		
+
         [DllImport(YoloLibraryName, EntryPoint = "get_net_width")]
         private static extern int LibGetNetWidth(IntPtr pDetector);
 
@@ -56,12 +56,13 @@ namespace Darknet
 
         public void Dispose()
         {
-		    if (pDetector != IntPtr.Zero) {
-		        DisposeYolo(pDetector);
+            if (pDetector != IntPtr.Zero)
+            {
+                DisposeYolo(pDetector);
                 pDetector = IntPtr.Zero;
             }
         }
-		
+
         public int NetworkWidth => LibGetNetWidth(pDetector);
 
         public int NetworkHeight => LibGetNetHeight(pDetector);

--- a/build/darknet/YoloWrapper.cs
+++ b/build/darknet/YoloWrapper.cs
@@ -47,7 +47,7 @@ namespace Darknet
             public bbox_t[] candidates;
         }
 
-		private IntPtr pDetector;
+        private IntPtr pDetector;
 
         public YoloWrapper(string configurationFilename, string weightsFilename, int gpu)
         {
@@ -56,8 +56,10 @@ namespace Darknet
 
         public void Dispose()
         {
-			if (pDetector != IntPtr.Zero)
-				DisposeYolo(pDetector);
+		    if (pDetector != IntPtr.Zero) {
+		        DisposeYolo(pDetector);
+                pDetector = IntPtr.Zero;
+            }
         }
 		
         public int NetworkWidth => LibGetNetWidth(pDetector);

--- a/build/darknet/YoloWrapper.cs
+++ b/build/darknet/YoloWrapper.cs
@@ -60,7 +60,7 @@ namespace Darknet
 				DisposeYolo(pDetector);
         }
 		
-		public int NetworkWidth => LibGetNetWidth(pDetector);
+        public int NetworkWidth => LibGetNetWidth(pDetector);
 
         public int NetworkHeight => LibGetNetHeight(pDetector);
 

--- a/build/darknet/YoloWrapper.cs
+++ b/build/darknet/YoloWrapper.cs
@@ -9,16 +9,25 @@ namespace Darknet
         private const int MaxObjects = 1000;
 
         [DllImport(YoloLibraryName, EntryPoint = "init")]
-        private static extern int InitializeYolo(string configurationFilename, string weightsFilename, int gpu);
+        private static extern IntPtr InitializeYolo(string configurationFilename, string weightsFilename, int gpu);
 
         [DllImport(YoloLibraryName, EntryPoint = "detect_image")]
-        private static extern int DetectImage(string filename, ref BboxContainer container);
+        private static extern int DetectImage(IntPtr pDetector, string filename, float threshold, ref BboxContainer container);
 
         [DllImport(YoloLibraryName, EntryPoint = "detect_mat")]
-        private static extern int DetectImage(IntPtr pArray, int nSize, ref BboxContainer container);
+        private static extern int DetectImage(IntPtr pDetector, IntPtr pArray, int nSize, float threshold, ref BboxContainer container);
+		
+        [DllImport(YoloLibraryName, EntryPoint = "get_net_width")]
+        private static extern int LibGetNetWidth(IntPtr pDetector);
+
+        [DllImport(YoloLibraryName, EntryPoint = "get_net_height")]
+        private static extern int LibGetNetHeight(IntPtr pDetector);
+
+        [DllImport(YoloLibraryName, EntryPoint = "get_net_color_depth")]
+        private static extern int LibGetNetColorDepth(IntPtr pDetector);
 
         [DllImport(YoloLibraryName, EntryPoint = "dispose")]
-        private static extern int DisposeYolo();
+        private static extern int DisposeYolo(IntPtr pDetector);
 
         [StructLayout(LayoutKind.Sequential)]
         public struct bbox_t
@@ -38,25 +47,34 @@ namespace Darknet
             public bbox_t[] candidates;
         }
 
+		private IntPtr pDetector;
+
         public YoloWrapper(string configurationFilename, string weightsFilename, int gpu)
         {
-            InitializeYolo(configurationFilename, weightsFilename, gpu);
+            pDetector = InitializeYolo(configurationFilename, weightsFilename, gpu);
         }
 
         public void Dispose()
         {
-            DisposeYolo();
+			if (pDetector != IntPtr.Zero)
+				DisposeYolo(pDetector);
         }
+		
+		public int NetworkWidth => LibGetNetWidth(pDetector);
 
-        public bbox_t[] Detect(string filename)
+        public int NetworkHeight => LibGetNetHeight(pDetector);
+
+        public int NetworkColorDepth => LibGetNetColorDepth(pDetector);
+
+        public bbox_t[] Detect(string filename, float threshold = 0.2f)
         {
             var container = new BboxContainer();
-            var count = DetectImage(filename, ref container);
+            var count = DetectImage(pDetector, filename, threshold, ref container);
 
             return container.candidates;
         }
 
-        public bbox_t[] Detect(byte[] imageData)
+        public bbox_t[] Detect(byte[] imageData, float threshold = 0.2f)
         {
             var container = new BboxContainer();
 
@@ -67,7 +85,7 @@ namespace Darknet
             {
                 // Copy the array to unmanaged memory.
                 Marshal.Copy(imageData, 0, pnt, imageData.Length);
-                var count = DetectImage(pnt, imageData.Length, ref container);
+                var count = DetectImage(pDetector, pnt, imageData.Length, threshold, ref container);
                 if (count == -1)
                 {
                     throw new NotSupportedException($"{YoloLibraryName} has no OpenCV support");

--- a/include/yolo_v2_class.hpp
+++ b/include/yolo_v2_class.hpp
@@ -55,19 +55,12 @@ struct bbox_t_container {
 #include <opencv2/imgproc/imgproc_c.h>   // C
 #endif
 
-extern "C" LIB_API int init(const char *configurationFilename, const char *weightsFilename, int gpu);
-extern "C" LIB_API int detect_image(const char *filename, bbox_t_container &container);
-extern "C" LIB_API int detect_mat(const uint8_t* data, const size_t data_length, bbox_t_container &container);
-extern "C" LIB_API int dispose();
-extern "C" LIB_API int get_device_count();
-extern "C" LIB_API int get_device_name(int gpu, char* deviceName);
-
 class Detector {
     std::shared_ptr<void> detector_gpu_ptr;
     std::deque<std::vector<bbox_t>> prev_bbox_vec_deque;
 public:
     const int cur_gpu_id;
-    float nms = .4;
+    float nms = .4f;
     bool wait_stream;
 
     LIB_API Detector(std::string cfg_filename, std::string weight_filename, int gpu_id = 0);


### PR DESCRIPTION
I am rusty with C++ and was never more than a beginner to start with.

Removes the static instance of the detector. Init now returns a pointer that the C# class will keep track of and pass to subsequent methods. This should allow the consumer to create multiple instances of the wrapper class as long as they have the memory available.

The network width/height and colordepth was exposed, as well as adding threshold to the detect calls.

The is no mutex or locking added. It is still up to the caller to handle that.

Also, I can remove if you want, I added the method detect_mat_ptr. This will take a pointer to an OpenCV Mat. I am using Emgu and I have access to the unmanaged objects pointer that I can pass to darknet. Since darknet doesn't modify the original object, it works well and avoids a lot of memory copies and image encode/decodes.

If you keep this in, there might be a better way to handle the conditional for not compiling with OPENCV.