### PR TITLE
added auto stop on avg loss

### DIFF
--- a/include/darknet.h
+++ b/include/darknet.h
@@ -537,6 +537,9 @@ typedef struct network {
     float *output;
     learning_rate_policy policy;
 
+//TC: avg loss to stop training..
+    float avg_loss;
+
     float learning_rate;
     float learning_rate_min;
     float learning_rate_max;

--- a/src/detector.c
+++ b/src/detector.c
@@ -288,6 +288,13 @@ void train_detector(char *datacfg, char *cfgfile, char *weightfile, int *gpus, i
             save_weights(net, buff);
         }
         free_data(train);
+
+//TC - stop if required avg loss was reached..
+        if (avg_loss < net.avg_loss)
+        {
+            fprintf(stderr, "\nTarget avg loss reached, stopping Training.\n\tAvg loss required:\t%f\n\tAvg loss reached:\t%f\n\n", net.avg_loss, avg_loss);
+            break;
+        }
     }
 #ifdef GPU
     if (ngpus != 1) sync_nets(nets, ngpus, 0);

--- a/src/parser.c
+++ b/src/parser.c
@@ -652,6 +652,9 @@ void parse_net_options(list *options, network *net)
     net->batch *= net->time_steps;
     net->subdivisions = subdivs;
 
+//TC: optional stop on average loss...
+    net->avg_loss = option_find_float_quiet(options, "avg_loss", 0.0001);
+
     net->adam = option_find_int_quiet(options, "adam", 0);
     if(net->adam){
         net->B1 = option_find_float(options, "B1", .9);


### PR DESCRIPTION
Added a net parameter to stop training when a specified avg loss is reached. similar to max_batch..  this works great in headless training when you want to stop at specified avg loss instead of batch..