### PR TITLE
Fix cv exception when using both optflow and the ZED

### DIFF
--- a/src/yolo_console_dll.cpp
+++ b/src/yolo_console_dll.cpp
@@ -129,7 +129,9 @@ cv::Mat slMat2cvMat(sl::Mat &input) {
 cv::Mat zed_capture_rgb(sl::Camera &zed) {
     sl::Mat left;
     zed.retrieveImage(left);
-    return slMat2cvMat(left).clone();
+    cv::Mat left_rgb;
+    cv::cvtColor(slMat2cvMat(left), left_rgb, CV_RGBA2RGB);
+    return left_rgb;
 }
 
 cv::Mat zed_capture_3d(sl::Camera &zed) {


### PR DESCRIPTION
Using `TRACK_OPTFLOW` and `ZED_STEREO` simultaneously results in a segmentation fault :

```
terminate called after throwing an instance of 'cv::Exception'
  what():  OpenCV(3.4.6) opencv-3.4.6/modules/cudaimgproc/src/color.cpp:496: error: (-215:Assertion failed) src.channels() == 3 in function 'BGR_to_GRAY'
```

That's because the ZED SDK is outputting RGBA images. This PR adds the OpenCV color conversion to get RGB left images.