### PR TITLE
Fixed Latin-1 comment because it could not be displayed in CJK multi-byte language.

### DIFF
--- a/src/detector.c
+++ b/src/detector.c
@@ -996,7 +996,7 @@ float validate_detector_map(char *datacfg, char *cfgfile, char *weightfile, floa
 
         // MS COCO - uses 101-Recall-points on PR-chart.
         // PascalVOC2007 - uses 11-Recall-points on PR-chart.
-        // PascalVOC2010–2012 - uses Area-Under-Curve on PR-chart.
+        // PascalVOC2010-2012 - uses Area-Under-Curve on PR-chart.
         // ImageNet - uses Area-Under-Curve on PR-chart.
 
         // correct mAP calculation: ImageNet, PascalVOC 2010-2012


### PR DESCRIPTION
Fixed Latin-1 comment because it could not be displayed in CJK multi-byte language.

// PascalVOC2010-2012 -> 0x96(-) to 0x2d(-)