### PR TITLE
Fix OpenMP Unix if CUDA disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ if(OpenCV_FOUND)
   target_compile_definitions(dark PUBLIC -DOPENCV)
 endif()
 
-if(WIN32 AND OPENMP_FOUND)
+if((WIN32 OR NOT ENABLE_CUDA) AND OPENMP_FOUND)
   target_link_libraries(darknet PUBLIC OpenMP::OpenMP_CXX)
   target_link_libraries(darknet PUBLIC OpenMP::OpenMP_C)
   target_link_libraries(dark PUBLIC OpenMP::OpenMP_CXX)


### PR DESCRIPTION
See the discussion from https://github.com/AlexeyAB/darknet/pull/3389

I overlooked the OpenMP support on non-win32 config without CUDA enabled. This fix will enable OpenMP if CUDA is not enabled on Unix (and every time, if possible, on win32)

@cenit Let me know if this is ok on your end