### PR TITLE
Best weight check between training sessions

### DIFF
--- a/src/detector.c
+++ b/src/detector.c
@@ -66,6 +66,16 @@ void train_detector(char *datacfg, char *cfgfile, char *weightfile, int *gpus, i
     srand(time(0));
     int seed = rand();
     int i;
+
+    float last_best_weight = -1;
+    char bw_buff[256];
+    sprintf(bw_buff, "%s/%s_best.weights", backup_directory, base);
+    FILE *best_weight_file;
+    if (best_weight_file = fopen(bw_buff, "r")) {
+        fclose(best_weight_file);
+        float last_best_weight = validate_detector_map(datacfg, cfgfile, bw_buff, 0.25, 0.5, 0, NULL);// &net_combined);
+    }
+
     for (i = 0; i < ngpus; ++i) {
         srand(seed);
 #ifdef GPU
@@ -110,7 +120,7 @@ void train_detector(char *datacfg, char *cfgfile, char *weightfile, int *gpus, i
     iter_save_last = get_current_batch(net);
     iter_map = get_current_batch(net);
     float mean_average_precision = -1;
-    float best_map = mean_average_precision;
+    float best_map = last_best_weight;
 
     load_args args = { 0 };
     args.w = net.w;


### PR DESCRIPTION
Just modified detector.c in order to check the best weight map every time a training session is started as described in https://github.com/AlexeyAB/darknet/issues/3452.

If *best.weights exist in backup path detector will do a map before start training, it will save it and initialize the best_map value, so now you can maintain your best weight across different training sessions :)
