### PR TITLE
Check if image does not require resizing

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -1275,6 +1275,8 @@ float bilinear_interpolate(image im, float x, float y, int c)
 
 image resize_image(image im, int w, int h)
 {
+    if (im.w == w && im.h == h) return copy_image(im);
+
     image resized = make_image(w, h, im.c);
     image part = make_image(w, im.h, im.c);
     int r, c, k;


### PR DESCRIPTION
Function image.c: image resize_image(image im, int w, int h) does full resize procedure even if it is not needed (image has target dimensions already).

This optimization is very useful when images and network dimensions are always equal (e.g training model for specific camera).