### PR TITLE
Removed useless snippet that only breaks if batch processing is enabled

### DIFF
--- a/src/yolo_layer.c
+++ b/src/yolo_layer.c
@@ -492,7 +492,9 @@ int get_yolo_detections(layer l, int w, int h, int netw, int neth, float thresh,
     //printf("\n l.batch = %d, l.w = %d, l.h = %d, l.n = %d \n", l.batch, l.w, l.h, l.n);
     int i,j,n;
     float *predictions = l.output;
-    if (l.batch == 2) avg_flipped_yolo(l);
+    // This snippet below is not necessary
+    // Need to comment it in order to batch processing >= 2 images
+    //if (l.batch == 2) avg_flipped_yolo(l);
     int count = 0;
     for (i = 0; i < l.w*l.h; ++i){
         int row = i / l.w;


### PR DESCRIPTION
Hi @AlexeyAB ! I noticed that If you are trying to do batch processing on two images this line of code in yolo_layer.c (ln: 495) will broke any detection. Doesn't make any sense to have  it, right? I would be very gratefull if this is merged since im trying to make batch processing work with the latest version of this repo :) 

` if (l.batch == 2) avg_flipped_yolo(l);`

Thanks in advance