### PR TITLE
mistake in 'Pre-trained models ' heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ More details: http://pjreddie.com/darknet/yolo/
 
 There are weights-file for different cfg-files (smaller size -> faster speed & lower accuracy:
 
-* `yolov3-openimages.cfg` (247 MB COCO **Yolo v3**) - requires 4 GB GPU-RAM: https://pjreddie.com/media/files/yolov3-openimages.weights
+* `yolov3-openimages.cfg` (247 MB OPENIMAGES **Yolo v3**) - requires 4 GB GPU-RAM: https://pjreddie.com/media/files/yolov3-openimages.weights
 * `yolov3-spp.cfg` (240 MB COCO **Yolo v3**) - requires 4 GB GPU-RAM: https://pjreddie.com/media/files/yolov3-spp.weights
 * `yolov3.cfg` (236 MB COCO **Yolo v3**) - requires 4 GB GPU-RAM: https://pjreddie.com/media/files/yolov3.weights
 * `yolov3-tiny.cfg` (34 MB COCO **Yolo v3 tiny**) - requires 1 GB GPU-RAM:  https://pjreddie.com/media/files/yolov3-tiny.weights


### PR DESCRIPTION
The first line is related to cfg and weights for openImages but in parenthesis you wrote COCO inplace of OPENIMAGES,so I corrected.