### PR TITLE
Fix compilation for Windows with MinGW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,10 @@ endif
 
 CFLAGS+=$(OPTS)
 
+ifneq (,$(findstring MSYS_NT,$(OS)))
+LDFLAGS+=-lws2_32
+endif
+
 ifeq ($(OPENCV), 1)
 COMMON+= -DOPENCV
 CFLAGS+= -DOPENCV

--- a/src/darkunistd.h
+++ b/src/darkunistd.h
@@ -7,7 +7,7 @@
 *  Please add functionality as needed
 */
 
-#include <Winsock2.h>
+#include <winsock2.h>
 #include <direct.h> /* for _getcwd() and _chdir() */
 #include "getopt.h"
 #include <io.h>

--- a/src/gemm.c
+++ b/src/gemm.c
@@ -512,7 +512,7 @@ static inline int popcnt_32(uint32_t val32) {
 //----------------------------
 
 
-#if (defined(__AVX__) && defined(__x86_64__)) || defined(_WIN64)
+#if (defined(__AVX__) && defined(__x86_64__)) || (defined(_WIN64) && !defined(__MINGW32__))
 
 #ifdef _WIN64
 #include <intrin.h>

--- a/src/getopt.h
+++ b/src/getopt.h
@@ -67,7 +67,7 @@
 #include <stdlib.h>
 #include <string.h>
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -190,13 +190,13 @@ extern "C" {
  *	Parse long options in argc/argv argument vector.
  * Returns -1 if short_too is set and the option does not match long_options.
  */
-static int parse_long_options(char* const* nargv, const char* options, const struct option* long_options, int* idx, int short_too);
+/* static int parse_long_options(char* const* nargv, const char* options, const struct option* long_options, int* idx, int short_too); */
 
 /*
  * getopt_internal --
  *	Parse argc/argv argument vector.  Called by user level routines.
  */
-static int getopt_internal(int nargc, char* const* nargv, const char* options, const struct option* long_options, int* idx, int flags);
+/* static int getopt_internal(int nargc, char* const* nargv, const char* options, const struct option* long_options, int* idx, int flags); */
 
 /*
  * getopt_long --

--- a/src/gettimeofday.h
+++ b/src/gettimeofday.h
@@ -1,9 +1,9 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#include <Winsock2.h>
+#include <windows.h>
+#include <winsock2.h>
 #include <stdint.h>
-#include < time.h >
+#include <time.h>
 #include "darknet.h"
 
 #define CLOCK_REALTIME (1)


### PR DESCRIPTION
Here are all other patches we applied to cross-compile Darknet for Windows with MinGW in #4323.