### PR TITLE
Minor fix

### DIFF
--- a/src/layer.c
+++ b/src/layer.c
@@ -184,7 +184,7 @@ void free_layer_custom(layer l, int keep_cudnn_desc)
     if (l.scale_updates_gpu)       cuda_free(l.scale_updates_gpu), l.scale_updates_gpu = NULL;
     if (l.input_antialiasing_gpu)  cuda_free(l.input_antialiasing_gpu), l.input_antialiasing_gpu = NULL;
     if (l.optimized_memory < 2) {
-        if (l.x_gpu)                   cuda_free(l.x_gpu);  l.x_gpu = NULL;
+        if (l.x_gpu)                   cuda_free(l.x_gpu),  l.x_gpu = NULL;
         if (l.output_gpu)              cuda_free(l.output_gpu), l.output_gpu = NULL;
         if (l.activation_input_gpu)    cuda_free(l.activation_input_gpu), l.activation_input_gpu = NULL;
     }


### PR DESCRIPTION
Found what appears to be a typo in `free_layer_custom` in `layer.c`, although it wouldn't cause bugs--just a variable with value `NULL` being set to `NULL`. It might just waste a bit of time if the compiler didn't optimize it out