### PR TITLE
Adding support for ZED SDK 3.0 (with 2.8 support maintained)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ OPENCV=0
 AVX=0
 OPENMP=0
 LIBSO=0
-ZED_CAMERA=0
+ZED_CAMERA=0 # ZED SDK 3.0 and above
+ZED_CAMERA_v2_8=0 # ZED SDK 2.X
 
 # set GPU=1 and CUDNN=1 to speedup on GPU
 # set CUDNN_HALF=1 to further speedup 3 x times (Mixed-precision on Tensor Cores) GPU: Volta, Xavier, Turing and higher
@@ -124,8 +125,13 @@ endif
 
 ifeq ($(ZED_CAMERA), 1)
 CFLAGS+= -DZED_STEREO -I/usr/local/zed/include
+ifeq ($(ZED_CAMERA_v2_8), 1)
 LDFLAGS+= -L/usr/local/zed/lib -lsl_core -lsl_input -lsl_zed
 #-lstdc++ -D_GLIBCXX_USE_CXX11_ABI=0 
+else
+LDFLAGS+= -L/usr/local/zed/lib -lsl_zed
+#-lstdc++ -D_GLIBCXX_USE_CXX11_ABI=0 
+endif
 endif
 
 OBJ=image_opencv.o http_stream.o gemm.o utils.o dark_cuda.o convolutional_layer.o list.o image.o activations.o im2col.o col2im.o blas.o crop_layer.o dropout_layer.o maxpool_layer.o softmax_layer.o data.o matrix.o network.o connected_layer.o cost_layer.o parser.o option_list.o darknet.o detection_layer.o captcha.o route_layer.o writing.o box.o nightmare.o normalization_layer.o avgpool_layer.o coco.o dice.o yolo.o detector.o layer.o compare.o classifier.o local_layer.o swag.o shortcut_layer.o activation_layer.o rnn_layer.o gru_layer.o rnn.o rnn_vid.o crnn_layer.o demo.o tag.o cifar.o go.o batchnorm_layer.o art.o region_layer.o reorg_layer.o reorg_old_layer.o super.o voxel.o tree.o yolo_layer.o gaussian_yolo_layer.o upsample_layer.o lstm_layer.o conv_lstm_layer.o scale_channels_layer.o sam_layer.o


### PR DESCRIPTION
This PR adds the support of the newly released ZED SDK 3.0 (which introduced breaking changes) while keeping the ZED SDK 2.x compatibility.

Please consider the [`#undef GPU`](https://github.com/AlexeyAB/darknet/compare/master...adujardin:zedsdk_3_support?expand=1#diff-3445cf22867b9f62dcc91c7264e727f6R32). It was necessary to solve the conflict with the new API which includes 'GPU' as an enum value (`sl::MEM::GPU`). This define doesn't seem to be used in the rest of the file, so the scope should be fine and no feature should be impacted, I think.

If you have time to test it, let me know if there's something to change.