### PR TITLE
Minor addition

### DIFF
--- a/include/darknet.h
+++ b/include/darknet.h
@@ -889,6 +889,7 @@ LIB_API network *load_network(char *cfg, char *weights, int clear);
 LIB_API network *load_network_custom(char *cfg, char *weights, int clear, int batch);
 LIB_API network *load_network(char *cfg, char *weights, int clear);
 LIB_API void free_network(network net);
+LIB_API void free_network_ptr(network* net);
 
 // network.c
 LIB_API load_args get_base_args(network *net);

--- a/src/network.c
+++ b/src/network.c
@@ -1029,6 +1029,11 @@ float network_accuracy_multi(network net, data d, int n)
     return acc;
 }
 
+void free_network_ptr(network* net)
+{
+    free_network(*net);
+}
+
 void free_network(network net)
 {
     int i;


### PR DESCRIPTION
Added method to free network from C# environment using network pointer instead of network object.

`LIB_API void free_network_ptr(network* net);`