### PR TITLE
Support building with OpenCV 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,8 @@ endif
 ifeq ($(OPENCV), 1)
 COMMON+= -DOPENCV
 CFLAGS+= -DOPENCV
-LDFLAGS+= `pkg-config --libs opencv`
-COMMON+= `pkg-config --cflags opencv`
+LDFLAGS+= `pkg-config --libs opencv4 2> /dev/null || pkg-config --libs opencv`
+COMMON+= `pkg-config --cflags opencv4 2> /dev/null || pkg-config --cflags opencv`
 endif
 
 ifeq ($(OPENMP), 1)

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ else
 CC=gcc
 endif
 
-CPP=g++
+CPP=g++ -std=c++11
 NVCC=nvcc
 OPTS=-Ofast
 LDFLAGS= -lm -pthread


### PR DESCRIPTION
I was asked to port https://github.com/pjreddie/darknet/pull/1348 to this repo. These changes allow building with OpenCV 4. The changes are much smaller than in the original darknet repo (https://github.com/pjreddie/darknet/pull/1348/files), since this repo was already avoiding the raw C API.

I tested building with the Makefile only. There might be work to be done on the CMake project.