### PR TITLE
Update classifier.c

### DIFF
--- a/src/classifier.c
+++ b/src/classifier.c
@@ -753,13 +753,14 @@ void try_classifier(char *datacfg, char *cfgfile, char *weightfile, char *filena
         float *predictions = network_predict(net, X);
 
         layer l = net.layers[layer_num];
-        for(int i = 0; i < l.c; ++i){
+        int i;
+        for(i = 0; i < l.c; ++i){
             if(l.rolling_mean) printf("%f %f %f\n", l.rolling_mean[i], l.rolling_variance[i], l.scales[i]);
         }
 #ifdef GPU
         cuda_pull_array(l.output_gpu, l.output, l.outputs);
 #endif
-        for(int i = 0; i < l.outputs; ++i){
+        for(i = 0; i < l.outputs; ++i){
             printf("%f\n", l.output[i]);
         }
         /*
@@ -777,7 +778,7 @@ void try_classifier(char *datacfg, char *cfgfile, char *weightfile, char *filena
 
         top_predictions(net, top, indexes);
         printf("%s: Predicted in %f seconds.\n", input, sec(clock()-time));
-        for(int i = 0; i < top; ++i){
+        for(i = 0; i < top; ++i){
             int index = indexes[i];
             printf("%s: %f\n", names[index], predictions[index]);
         }


### PR DESCRIPTION
declaring variables not allowed within "for loops" until C99. additionally. declaring int i multiple times within the same definition try_classifier  isn't necessary

AWS, an increasingly common usage throws a syntax error not styled as above

eg.

```c
./src/classifier.c: In function ‘try_classifier’:
./src/classifier.c:756:9: error: ‘for’ loop initial declarations are only allowed in C99 mode
         for(int i = 0; i < l.c; ++i){
```