### PR TITLE
fix the quantize_image function of image.c

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -1308,6 +1308,7 @@ image quantize_image(image im)
     int size = im.c * im.w * im.h;
     int i;
     for (i = 0; i < size; ++i) im.data[i] = (int)(im.data[i] * 255) / 255. + (0.5/255);
+    return im;
 }
 
 void make_image_red(image im)


### PR DESCRIPTION
There is no return value in the quantize_image of image.c. After setting BUILD_SHARED_LIBS and using cmake to build .sln, we open it and generate the ALL_BUILD project. But there is an error showing that quantize_image has no return value. So I add the return value in the function.