### PR TITLE
Giving python wrapper almost same functionalities and interface as C code

### DIFF
--- a/darknet.py
+++ b/darknet.py
@@ -47,10 +47,6 @@ class DETECTION(Structure):
                 ("sim", c_float),
                 ("track_id", c_int)]
 
-
-
-
-
 class DETNUMPAIR(Structure):
     _fields_ = [("num", c_int),
                 ("dets", POINTER(DETECTION))]

--- a/darknet.py
+++ b/darknet.py
@@ -4,7 +4,8 @@ Python 3 wrapper for identifying objects in images
 
 Requires DLL compilation
 
-Both the GPU and no-GPU version should be compiled; the no-GPU version should be renamed "yolo_cpp_dll_nogpu.dll".
+Both the GPU and no-GPU version should be compiled; the no-GPU version should
+be renamed "yolo_cpp_dll_nogpu.dll".
 
 On a GPU system, you can force CPU evaluation by any of:
 
@@ -13,39 +14,22 @@ On a GPU system, you can force CPU evaluation by any of:
 - Set environment variable "FORCE_CPU" to "true"
 
 
-To use, either run performDetect() after import, or modify the end of this file.
-
-See the docstring of performDetect() for parameters.
-
-Directly viewing or returning bounding-boxed images requires scikit-image to be installed (`pip install scikit-image`)
+Directly viewing or returning bounding-boxed images requires OpenCV
+to be installed (`pip install opencv-python`)
 
 
 Original *nix 2.7: https://github.com/pjreddie/darknet/blob/0f110834f4e18b30d5f101bf8f1724c34b7b83db/python/darknet.py
 Windows Python 2.7 version: https://github.com/AlexeyAB/darknet/blob/fc496d52bf22a0bb257300d3c79be9cd80e722cb/build/darknet/x64/darknet.py
 
 @author: Philip Kahn
-@date: 20180503
+@author: Jaled Moustafa Calvo
+@date: 09/04/2020
 """
-#pylint: disable=R, W0401, W0614, W0703
 from ctypes import *
-import math
-import random
 import os
+import re
+import random
 
-def sample(probs):
-    s = sum(probs)
-    probs = [a/s for a in probs]
-    r = random.uniform(0, 1)
-    for i in range(len(probs)):
-        r = r - probs[i]
-        if r <= 0:
-            return i
-    return len(probs)-1
-
-def c_array(ctype, values):
-    arr = (ctype*len(values))()
-    arr[:] = values
-    return arr
 
 class BOX(Structure):
     _fields_ = [("x", c_float),
@@ -63,9 +47,6 @@ class DETECTION(Structure):
                 ("uc", POINTER(c_float)),
                 ("points", c_int)]
 
-class DETNUMPAIR(Structure):
-    _fields_ = [("num", c_int),
-                ("dets", POINTER(DETECTION))]
 
 class IMAGE(Structure):
     _fields_ = [("w", c_int),
@@ -78,9 +59,125 @@ class METADATA(Structure):
                 ("names", POINTER(c_char_p))]
 
 
+def network_width(net):
+    return lib.network_width(net)
 
-#lib = CDLL("/home/pjreddie/documents/darknet/libdarknet.so", RTLD_GLOBAL)
-#lib = CDLL("libdarknet.so", RTLD_GLOBAL)
+
+def network_height(net):
+    return lib.network_height(net)
+
+
+def class_colors(names):
+    """
+    Create a dict with one random BGR color for each
+    class name
+    """
+    return {name:(
+        random.randint(0, 255),
+        random.randint(0, 255),
+        random.randint(0, 255)) for name in names}
+   
+
+def decode_detection(detections):
+    decoded = []
+    for label, confidence, bbox in detections:
+        confidence = str(round(confidence * 100, 2))
+        decoded.append((str(label), confidence, bbox))
+    return decoded
+
+
+def bbox2points(bbox):
+    """
+    From bounding box yolo format 
+    to corner points cv2 rectangle
+    """
+    x, y, w, h = bbox
+    xmin = int(round(x - (w / 2)))
+    xmax = int(round(x + (w / 2)))
+    ymin = int(round(y - (h / 2)))
+    ymax = int(round(y + (h / 2)))
+    return (xmin, ymin), (xmax, ymax)
+
+
+def draw_boxes(detections, image, colors):
+    import cv2
+    for label, confidence, bbox in detections:
+        pt1, pt2 = bbox2points(bbox)
+        cv2.rectangle(image, pt1, pt2, colors[label], 1)
+        cv2.putText(image, "{} [{}]".format(label, confidence),
+                    (pt1[0], pt1[1] - 5), cv2.FONT_HERSHEY_SIMPLEX, 0.5,
+                    colors[label], 2)
+    return image
+
+
+def print_detections(detections, coordinates=False):
+    print("\nObjects:")
+    for label, confidence, bbox in detections:
+        x, y, w, h = bbox
+        if coordinates:
+            print("{}: {}%    (left_x: {:.0f}   top_y:  {:.0f}   width:   {:.0f}   height:  {:.0f})".format(label, confidence, x, y, w, h))
+        else:
+            print("{}: {}%".format(label, confidence))
+
+
+def load_network(config_file, data_file, weights):
+    """
+    load model description and weights from config files
+    args:
+        config_file (str): path to .cfg model file
+        data_file (str): path to .data model file
+        weights (str): path to weights
+    returns:
+        network: trained model
+        class_names
+        class_colors      
+    """
+    network = load_net_custom(
+        config_file.encode("ascii"),
+        weights.encode("ascii"), 0, 1)  # batch size = 1
+    metadata = load_meta(data_file.encode("ascii"))
+    class_names = [metadata.names[i].decode("ascii") for i in range(metadata.classes)]
+    colors = class_colors(class_names)
+    return network, class_names, colors
+
+
+def remove_negatives(detections, class_names, num):
+    """
+    Remove all classes with 0% confidence within the detection
+    """
+    predictions = []
+    for j in range(num):
+        for idx, name in enumerate(class_names):
+            if detections[j].prob[idx] > 0:
+                bbox = detections[j].bbox
+                bbox = (bbox.x, bbox.y, bbox.w, bbox.h)
+                predictions.append((name, detections[j].prob[idx], (bbox)))
+    return predictions
+
+
+def detect_image(network, class_names, image, thresh=.5, hier_thresh=.5, nms=.45):
+    """
+        Returns a list with highest confidence class and their bbox
+    """
+    pnum = pointer(c_int(0))
+    predict_image(network, image)
+    detections = get_network_boxes(network, image.w, image.h,
+                                   thresh, hier_thresh, None, 0, pnum, 0)
+    num = pnum[0]
+    if nms:
+        do_nms_sort(detections, num, len(class_names), nms)
+    predictions = remove_negatives(detections, class_names, num)
+    predictions = decode_detection(predictions)
+    free_detections(detections, num)
+    return sorted(predictions, key=lambda x: x[1])
+
+
+def classify(network, meta, image):
+    detections = predict_image(network, image)
+    predictions = [(name, detection[idx]) for idx, name in enumerate(class_names)]
+    return sorted(predictions, key=lambda x: -x[1])
+
+
 hasGPU = True
 if os.name == "nt":
     cwd = os.path.dirname(__file__)
@@ -108,7 +205,6 @@ if os.name == "nt":
                     raise ValueError("ForceCPU")
             except NameError:
                 pass
-            # print(os.environ.keys())
             # print("FORCE_CPU flag undefined, proceeding with GPU")
         if not os.path.exists(winGPUdll):
             raise ValueError("NoDLL")
@@ -132,12 +228,6 @@ lib.network_height.restype = c_int
 
 copy_image_from_bytes = lib.copy_image_from_bytes
 copy_image_from_bytes.argtypes = [IMAGE,c_char_p]
-
-def network_width(net):
-    return lib.network_width(net)
-
-def network_height(net):
-    return lib.network_height(net)
 
 predict = lib.network_predict_ptr
 predict.argtypes = [c_void_p, POINTER(c_float)]
@@ -163,9 +253,6 @@ make_network_boxes.restype = POINTER(DETECTION)
 
 free_detections = lib.free_detections
 free_detections.argtypes = [POINTER(DETECTION), c_int]
-
-free_batch_detections = lib.free_batch_detections
-free_batch_detections.argtypes = [POINTER(DETNUMPAIR), c_int]
 
 free_ptrs = lib.free_ptrs
 free_ptrs.argtypes = [POINTER(c_void_p), c_int]
@@ -215,313 +302,3 @@ predict_image.restype = POINTER(c_float)
 predict_image_letterbox = lib.network_predict_image_letterbox
 predict_image_letterbox.argtypes = [c_void_p, IMAGE]
 predict_image_letterbox.restype = POINTER(c_float)
-
-network_predict_batch = lib.network_predict_batch
-network_predict_batch.argtypes = [c_void_p, IMAGE, c_int, c_int, c_int,
-                                   c_float, c_float, POINTER(c_int), c_int, c_int]
-network_predict_batch.restype = POINTER(DETNUMPAIR)
-
-def array_to_image(arr):
-    import numpy as np
-    # need to return old values to avoid python freeing memory
-    arr = arr.transpose(2,0,1)
-    c = arr.shape[0]
-    h = arr.shape[1]
-    w = arr.shape[2]
-    arr = np.ascontiguousarray(arr.flat, dtype=np.float32) / 255.0
-    data = arr.ctypes.data_as(POINTER(c_float))
-    im = IMAGE(w,h,c,data)
-    return im, arr
-
-def classify(net, meta, im):
-    out = predict_image(net, im)
-    res = []
-    for i in range(meta.classes):
-        if altNames is None:
-            nameTag = meta.names[i]
-        else:
-            nameTag = altNames[i]
-        res.append((nameTag, out[i]))
-    res = sorted(res, key=lambda x: -x[1])
-    return res
-
-def detect(net, meta, image, thresh=.5, hier_thresh=.5, nms=.45, debug= False):
-    """
-    Performs the meat of the detection
-    """
-    #pylint: disable= C0321
-    im = load_image(image, 0, 0)
-    if debug: print("Loaded image")
-    ret = detect_image(net, meta, im, thresh, hier_thresh, nms, debug)
-    free_image(im)
-    if debug: print("freed image")
-    return ret
-
-def detect_image(net, meta, im, thresh=.5, hier_thresh=.5, nms=.45, debug= False):
-    #import cv2
-    #custom_image_bgr = cv2.imread(image) # use: detect(,,imagePath,)
-    #custom_image = cv2.cvtColor(custom_image_bgr, cv2.COLOR_BGR2RGB)
-    #custom_image = cv2.resize(custom_image,(lib.network_width(net), lib.network_height(net)), interpolation = cv2.INTER_LINEAR)
-    #import scipy.misc
-    #custom_image = scipy.misc.imread(image)
-    #im, arr = array_to_image(custom_image)		# you should comment line below: free_image(im)
-    num = c_int(0)
-    if debug: print("Assigned num")
-    pnum = pointer(num)
-    if debug: print("Assigned pnum")
-    predict_image(net, im)
-    letter_box = 0
-    #predict_image_letterbox(net, im)
-    #letter_box = 1
-    if debug: print("did prediction")
-    #dets = get_network_boxes(net, custom_image_bgr.shape[1], custom_image_bgr.shape[0], thresh, hier_thresh, None, 0, pnum, letter_box) # OpenCV
-    dets = get_network_boxes(net, im.w, im.h, thresh, hier_thresh, None, 0, pnum, letter_box)
-    if debug: print("Got dets")
-    num = pnum[0]
-    if debug: print("got zeroth index of pnum")
-    if nms:
-        do_nms_sort(dets, num, meta.classes, nms)
-    if debug: print("did sort")
-    res = []
-    if debug: print("about to range")
-    for j in range(num):
-        if debug: print("Ranging on "+str(j)+" of "+str(num))
-        if debug: print("Classes: "+str(meta), meta.classes, meta.names)
-        for i in range(meta.classes):
-            if debug: print("Class-ranging on "+str(i)+" of "+str(meta.classes)+"= "+str(dets[j].prob[i]))
-            if dets[j].prob[i] > 0:
-                b = dets[j].bbox
-                if altNames is None:
-                    nameTag = meta.names[i]
-                else:
-                    nameTag = altNames[i]
-                if debug:
-                    print("Got bbox", b)
-                    print(nameTag)
-                    print(dets[j].prob[i])
-                    print((b.x, b.y, b.w, b.h))
-                res.append((nameTag, dets[j].prob[i], (b.x, b.y, b.w, b.h)))
-    if debug: print("did range")
-    res = sorted(res, key=lambda x: -x[1])
-    if debug: print("did sort")
-    free_detections(dets, num)
-    if debug: print("freed detections")
-    return res
-
-
-netMain = None
-metaMain = None
-altNames = None
-
-def performDetect(imagePath="data/dog.jpg", thresh= 0.25, configPath = "./cfg/yolov4.cfg", weightPath = "yolov4.weights", metaPath= "./cfg/coco.data", showImage= True, makeImageOnly = False, initOnly= False):
-    """
-    Convenience function to handle the detection and returns of objects.
-
-    Displaying bounding boxes requires libraries scikit-image and numpy
-
-    Parameters
-    ----------------
-    imagePath: str
-        Path to the image to evaluate. Raises ValueError if not found
-
-    thresh: float (default= 0.25)
-        The detection threshold
-
-    configPath: str
-        Path to the configuration file. Raises ValueError if not found
-
-    weightPath: str
-        Path to the weights file. Raises ValueError if not found
-
-    metaPath: str
-        Path to the data file. Raises ValueError if not found
-
-    showImage: bool (default= True)
-        Compute (and show) bounding boxes. Changes return.
-
-    makeImageOnly: bool (default= False)
-        If showImage is True, this won't actually *show* the image, but will create the array and return it.
-
-    initOnly: bool (default= False)
-        Only initialize globals. Don't actually run a prediction.
-
-    Returns
-    ----------------------
-
-
-    When showImage is False, list of tuples like
-        ('obj_label', confidence, (bounding_box_x_px, bounding_box_y_px, bounding_box_width_px, bounding_box_height_px))
-        The X and Y coordinates are from the center of the bounding box. Subtract half the width or height to get the lower corner.
-
-    Otherwise, a dict with
-        {
-            "detections": as above
-            "image": a numpy array representing an image, compatible with scikit-image
-            "caption": an image caption
-        }
-    """
-    # Import the global variables. This lets us instance Darknet once, then just call performDetect() again without instancing again
-    global metaMain, netMain, altNames #pylint: disable=W0603
-    assert 0 < thresh < 1, "Threshold should be a float between zero and one (non-inclusive)"
-    if not os.path.exists(configPath):
-        raise ValueError("Invalid config path `"+os.path.abspath(configPath)+"`")
-    if not os.path.exists(weightPath):
-        raise ValueError("Invalid weight path `"+os.path.abspath(weightPath)+"`")
-    if not os.path.exists(metaPath):
-        raise ValueError("Invalid data file path `"+os.path.abspath(metaPath)+"`")
-    if netMain is None:
-        netMain = load_net_custom(configPath.encode("ascii"), weightPath.encode("ascii"), 0, 1)  # batch size = 1
-    if metaMain is None:
-        metaMain = load_meta(metaPath.encode("ascii"))
-    if altNames is None:
-        # In Python 3, the metafile default access craps out on Windows (but not Linux)
-        # Read the names file and create a list to feed to detect
-        try:
-            with open(metaPath) as metaFH:
-                metaContents = metaFH.read()
-                import re
-                match = re.search("names *= *(.*)$", metaContents, re.IGNORECASE | re.MULTILINE)
-                if match:
-                    result = match.group(1)
-                else:
-                    result = None
-                try:
-                    if os.path.exists(result):
-                        with open(result) as namesFH:
-                            namesList = namesFH.read().strip().split("\n")
-                            altNames = [x.strip() for x in namesList]
-                except TypeError:
-                    pass
-        except Exception:
-            pass
-    if initOnly:
-        print("Initialized detector")
-        return None
-    if not os.path.exists(imagePath):
-        raise ValueError("Invalid image path `"+os.path.abspath(imagePath)+"`")
-    # Do the detection
-    #detections = detect(netMain, metaMain, imagePath, thresh)	# if is used cv2.imread(image)
-    detections = detect(netMain, metaMain, imagePath.encode("ascii"), thresh)
-    if showImage:
-        try:
-            from skimage import io, draw
-            import numpy as np
-            image = io.imread(imagePath)
-            print("*** "+str(len(detections))+" Results, color coded by confidence ***")
-            imcaption = []
-            for detection in detections:
-                label = detection[0]
-                confidence = detection[1]
-                pstring = label+": "+str(np.rint(100 * confidence))+"%"
-                imcaption.append(pstring)
-                print(pstring)
-                bounds = detection[2]
-                shape = image.shape
-                # x = shape[1]
-                # xExtent = int(x * bounds[2] / 100)
-                # y = shape[0]
-                # yExtent = int(y * bounds[3] / 100)
-                yExtent = int(bounds[3])
-                xEntent = int(bounds[2])
-                # Coordinates are around the center
-                xCoord = int(bounds[0] - bounds[2]/2)
-                yCoord = int(bounds[1] - bounds[3]/2)
-                boundingBox = [
-                    [xCoord, yCoord],
-                    [xCoord, yCoord + yExtent],
-                    [xCoord + xEntent, yCoord + yExtent],
-                    [xCoord + xEntent, yCoord]
-                ]
-                # Wiggle it around to make a 3px border
-                rr, cc = draw.polygon_perimeter([x[1] for x in boundingBox], [x[0] for x in boundingBox], shape= shape)
-                rr2, cc2 = draw.polygon_perimeter([x[1] + 1 for x in boundingBox], [x[0] for x in boundingBox], shape= shape)
-                rr3, cc3 = draw.polygon_perimeter([x[1] - 1 for x in boundingBox], [x[0] for x in boundingBox], shape= shape)
-                rr4, cc4 = draw.polygon_perimeter([x[1] for x in boundingBox], [x[0] + 1 for x in boundingBox], shape= shape)
-                rr5, cc5 = draw.polygon_perimeter([x[1] for x in boundingBox], [x[0] - 1 for x in boundingBox], shape= shape)
-                boxColor = (int(255 * (1 - (confidence ** 2))), int(255 * (confidence ** 2)), 0)
-                draw.set_color(image, (rr, cc), boxColor, alpha= 0.8)
-                draw.set_color(image, (rr2, cc2), boxColor, alpha= 0.8)
-                draw.set_color(image, (rr3, cc3), boxColor, alpha= 0.8)
-                draw.set_color(image, (rr4, cc4), boxColor, alpha= 0.8)
-                draw.set_color(image, (rr5, cc5), boxColor, alpha= 0.8)
-            if not makeImageOnly:
-                io.imshow(image)
-                io.show()
-            detections = {
-                "detections": detections,
-                "image": image,
-                "caption": "\n<br/>".join(imcaption)
-            }
-        except Exception as e:
-            print("Unable to show image: "+str(e))
-    return detections
-
-def performBatchDetect(thresh= 0.25, configPath = "./cfg/yolov4.cfg", weightPath = "yolov4.weights", metaPath= "./cfg/coco.data", hier_thresh=.5, nms=.45, batch_size=3):
-    import cv2
-    import numpy as np
-    # NB! Image sizes should be the same
-    # You can change the images, yet, be sure that they have the same width and height
-    img_samples = ['data/person.jpg', 'data/person.jpg', 'data/person.jpg']
-    image_list = [cv2.imread(k) for k in img_samples]
-
-    net = load_net_custom(configPath.encode('utf-8'), weightPath.encode('utf-8'), 0, batch_size)
-    meta = load_meta(metaPath.encode('utf-8'))
-    pred_height, pred_width, c = image_list[0].shape
-    net_width, net_height = (network_width(net), network_height(net))
-    img_list = []
-    for custom_image_bgr in image_list:
-        custom_image = cv2.cvtColor(custom_image_bgr, cv2.COLOR_BGR2RGB)
-        custom_image = cv2.resize(
-            custom_image, (net_width, net_height), interpolation=cv2.INTER_NEAREST)
-        custom_image = custom_image.transpose(2, 0, 1)
-        img_list.append(custom_image)
-
-    arr = np.concatenate(img_list, axis=0)
-    arr = np.ascontiguousarray(arr.flat, dtype=np.float32) / 255.0
-    data = arr.ctypes.data_as(POINTER(c_float))
-    im = IMAGE(net_width, net_height, c, data)
-
-    batch_dets = network_predict_batch(net, im, batch_size, pred_width,
-                                                pred_height, thresh, hier_thresh, None, 0, 0)
-    batch_boxes = []
-    batch_scores = []
-    batch_classes = []
-    for b in range(batch_size):
-        num = batch_dets[b].num
-        dets = batch_dets[b].dets
-        if nms:
-            do_nms_obj(dets, num, meta.classes, nms)
-        boxes = []
-        scores = []
-        classes = []
-        for i in range(num):
-            det = dets[i]
-            score = -1
-            label = None
-            for c in range(det.classes):
-                p = det.prob[c]
-                if p > score:
-                    score = p
-                    label = c
-            if score > thresh:
-                box = det.bbox
-                left, top, right, bottom = map(int,(box.x - box.w / 2, box.y - box.h / 2,
-                                            box.x + box.w / 2, box.y + box.h / 2))
-                boxes.append((top, left, bottom, right))
-                scores.append(score)
-                classes.append(label)
-                boxColor = (int(255 * (1 - (score ** 2))), int(255 * (score ** 2)), 0)
-                cv2.rectangle(image_list[b], (left, top),
-                          (right, bottom), boxColor, 2)
-        cv2.imwrite(os.path.basename(img_samples[b]),image_list[b])
-
-        batch_boxes.append(boxes)
-        batch_scores.append(scores)
-        batch_classes.append(classes)
-    free_batch_detections(batch_dets, batch_size)
-    return batch_boxes, batch_scores, batch_classes    
-
-if __name__ == "__main__":
-    print(performDetect())
-    #Uncomment the following line to see batch inference working 
-    #print(performBatchDetect())

--- a/darknet.py
+++ b/darknet.py
@@ -48,6 +48,9 @@ class DETECTION(Structure):
                 ("track_id", c_int)]
 
 
+
+
+
 class DETNUMPAIR(Structure):
     _fields_ = [("num", c_int),
                 ("dets", POINTER(DETECTION))]

--- a/darknet_images.py
+++ b/darknet_images.py
@@ -1,0 +1,144 @@
+import argparse
+import os
+import glob
+import random
+import darknet
+import time
+import cv2
+
+
+def parser():
+    parser = argparse.ArgumentParser(description="YOLO Object Detection")
+    parser.add_argument("--input", type=str, default="",
+                        help="image source. It can be a single image, a"
+                        "txt with paths to them, or a folder. Image valid"
+                        " formats are jpg, jpeg or png."
+                        "If no input is given, ")
+    parser.add_argument("--weights", default="yolov4.weights",
+                        help="yolo weights path")
+    parser.add_argument("--dont_show", action='store_true',
+                        help="windown inference display. For headless systems")
+    parser.add_argument("--ext_output", action='store_true',
+                        help="display bbox coordinates of detected objects")
+    parser.add_argument("--save_labels", action='store_true',
+                        help="save detections bbox for each image in yolo format")
+    parser.add_argument("--config_file", default="./cfg/yolov4.cfg",
+                        help="path to config file")
+    parser.add_argument("--data_file", default="./cfg/coco.data",
+                        help="path to data file")
+    parser.add_argument("--thresh", type=float, default=.25,
+                        help="remove detections with lower confidence")
+    return parser.parse_args()
+
+
+def check_arguments_errors(args):
+    assert 0 < args.thresh < 1, "Threshold should be a float between zero and one (non-inclusive)"
+    if not os.path.exists(args.config_file):
+        raise(ValueError("Invalid config path {}".format(os.path.abspath(args.config_file))))
+    if not os.path.exists(args.weights):
+        raise(ValueError("Invalid weight path {}".format(os.path.abspath(args.weights))))
+    if not os.path.exists(args.data_file):
+        raise(ValueError("Invalid data file path {}".format(os.path.abspath(args.data_file))))
+    if args.input and not os.path.exists(args.input):
+        raise(ValueError("Invalid image path {}".format(os.path.abspath(args.input))))
+
+
+def load_images(images_path):
+    """
+    If image path is given, return it directly
+    For txt file, read it and return each line as image path
+    In other case, it's a folder, return a list with names of each
+    jpg, jpeg and png file
+    """
+    input_path_extension = images_path.split('.')[-1]
+    if input_path_extension in ['jpg', 'jpeg', 'png']:
+        return [images_path]
+    elif input_path_extension == "txt":
+        with open(images_path, "r") as f:
+            return f.read().splitlines()
+    else:
+        return glob.glob(
+            os.path.join(images_path, "*.jpg")) + \
+            glob.glob(os.path.join(images_path, "*.png")) + \
+            glob.glob(os.path.join(images_path, "*.jpeg"))
+
+
+def image_detection(image_path, network, class_names, class_colors, thresh):
+    # Darknet doesn't accept numpy images.
+    # Create one with image we reuse for each detect
+    width = darknet.network_width(network)
+    height = darknet.network_height(network)
+    darknet_image = darknet.make_image(width, height, 3)
+
+    image = cv2.imread(image_path)
+    image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+    image_resized = cv2.resize(image_rgb, (width, height),
+                               interpolation=cv2.INTER_LINEAR)
+
+    darknet.copy_image_from_bytes(darknet_image, image_resized.tobytes())
+    detections = darknet.detect_image(network, class_names, darknet_image, thresh=thresh)
+    image = darknet.draw_boxes(detections, image_resized, class_colors)
+    return cv2.cvtColor(image, cv2.COLOR_BGR2RGB), detections
+
+
+def convert2relative(image, bbox):
+    """
+    YOLO format use relative coordinates for annotation
+    """
+    x, y, w, h = bbox
+    width, height, _ = image.shape
+    return x/width, y/height, w/width, h/height
+
+
+def save_annotations(name, image, detections, class_names):
+    """
+    Files saved with image_name.txt and relative coordinates
+    """
+    file_name = name.split(".")[:-1][0] + ".txt"
+    with open(file_name, "w") as f:
+        for label, confidence, bbox in detections:
+            x, y, w, h = convert2relative(image, bbox)
+            label = class_names.index(label)
+            f.write("{} {:.4f} {:.4f} {:.4f} {:.4f}\n".format(label, x, y, w, h))
+
+
+def main():
+    args = parser()
+    check_arguments_errors(args)
+
+    random.seed(3)  # deterministic bbox colors
+    network, class_names, class_colors = darknet.load_network(
+        args.config_file,
+        args.data_file,
+        args.weights
+    )
+
+    images = load_images(args.input)
+
+    index = 0
+    while True:
+        # loop asking for new image paths if no list is given
+        if args.input:
+            if index >= len(images):
+                break
+            image_name = images[index]
+        else:
+            image_name = input("Enter Image Path: ")
+        prev_time = time.time()
+        image, detections = image_detection(
+            image_name, network, class_names, class_colors, args.thresh
+            )
+        if args.save_labels:
+            save_annotations(image_name, image, detections, class_names)
+        darknet.print_detections(detections, args.ext_output)
+        fps = int(1/(time.time() - prev_time))
+        print("FPS: {}".format(fps))
+        if not args.dont_show:
+            cv2.imshow('Inference', image)
+            if cv2.waitKey() & 0xFF == ord('q'):
+                break
+        index += 1
+
+
+if __name__ == "__main__":
+    main()

--- a/darknet_images.py
+++ b/darknet_images.py
@@ -5,6 +5,8 @@ import random
 import darknet
 import time
 import cv2
+import numpy as np
+import darknet
 
 
 def parser():
@@ -14,6 +16,8 @@ def parser():
                         "txt with paths to them, or a folder. Image valid"
                         " formats are jpg, jpeg or png."
                         "If no input is given, ")
+    parser.add_argument("--batch_size", default=1, type=int,
+                        help="number of images to be processed at the same time")
     parser.add_argument("--weights", default="yolov4.weights",
                         help="yolo weights path")
     parser.add_argument("--dont_show", action='store_true',
@@ -43,6 +47,18 @@ def check_arguments_errors(args):
         raise(ValueError("Invalid image path {}".format(os.path.abspath(args.input))))
 
 
+def check_batch_shape(images, batch_size):
+    """
+        Image sizes should be the same width and height
+    """
+    shapes = [image.shape for image in images]
+    if len(set(shapes)) > 1:
+        raise ValueError("Images don't have same shape")
+    if len(shapes) > batch_size:
+        raise ValueError("Batch size higher than number of images")
+    return shapes[0]
+
+
 def load_images(images_path):
     """
     If image path is given, return it directly
@@ -63,6 +79,24 @@ def load_images(images_path):
             glob.glob(os.path.join(images_path, "*.jpeg"))
 
 
+def prepare_batch(images, network, channels=3):
+    width = darknet.network_width(network)
+    height = darknet.network_height(network)
+
+    darknet_images = []
+    for image in images:
+        image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+        image_resized = cv2.resize(image_rgb, (width, height),
+                                   interpolation=cv2.INTER_LINEAR)
+        custom_image = image_resized.transpose(2, 0, 1)
+        darknet_images.append(custom_image)
+
+    batch_array = np.concatenate(darknet_images, axis=0)
+    batch_array = np.ascontiguousarray(batch_array.flat, dtype=np.float32)/255.0
+    darknet_images = batch_array.ctypes.data_as(darknet.POINTER(darknet.c_float))
+    return darknet.IMAGE(width, height, channels, darknet_images)
+
+
 def image_detection(image_path, network, class_names, class_colors, thresh):
     # Darknet doesn't accept numpy images.
     # Create one with image we reuse for each detect
@@ -79,6 +113,25 @@ def image_detection(image_path, network, class_names, class_colors, thresh):
     detections = darknet.detect_image(network, class_names, darknet_image, thresh=thresh)
     image = darknet.draw_boxes(detections, image_resized, class_colors)
     return cv2.cvtColor(image, cv2.COLOR_BGR2RGB), detections
+
+
+def batch_detection(network, images, class_names, class_colors,
+                    thresh=0.25, hier_thresh=.5, nms=.45, batch_size=4):
+    image_height, image_width, _ = check_batch_shape(images, batch_size)
+    darknet_images = prepare_batch(images, network)
+    batch_detections = darknet.network_predict_batch(network, darknet_images, batch_size, image_width,
+                                                     image_height, thresh, hier_thresh, None, 0, 0)
+    batch_predictions = []
+    for idx in range(batch_size):
+        num = batch_detections[idx].num
+        detections = batch_detections[idx].dets
+        if nms:
+            darknet.do_nms_obj(detections, num, len(class_names), nms)
+        predictions = darknet.remove_negatives(detections, class_names, num)
+        images[idx] = darknet.draw_boxes(predictions, images[idx], class_colors)
+        batch_predictions.append(predictions)
+    darknet.free_batch_detections(batch_detections, batch_size)
+    return images, batch_predictions
 
 
 def convert2relative(image, bbox):
@@ -99,7 +152,27 @@ def save_annotations(name, image, detections, class_names):
         for label, confidence, bbox in detections:
             x, y, w, h = convert2relative(image, bbox)
             label = class_names.index(label)
-            f.write("{} {:.4f} {:.4f} {:.4f} {:.4f} {:.4f}\n".format(label, x, y, w, h, confidence))
+            f.write("{} {:.4f} {:.4f} {:.4f} {:.4f} {:.4f}\n".format(label, x, y, w, h, float(confidence)))
+
+
+def batch_detection_example():
+    args = parser()
+    check_arguments_errors(args)
+    batch_size = 3
+    random.seed(3)  # deterministic bbox colors
+    network, class_names, class_colors = darknet.load_network(
+        args.config_file,
+        args.data_file,
+        args.weights,
+        batch_size=batch_size
+    )
+    image_names = ['data/horses.jpg', 'data/horses.jpg', 'data/eagle.jpg']
+    images = [cv2.imread(image) for image in image_names]
+    images, detections,  = batch_detection(network, images, class_names,
+                                           class_colors, batch_size=batch_size)
+    for name, image in zip(image_names, images):
+        cv2.imwrite(name.replace("data/", ""), image)
+    print(detections)
 
 
 def main():
@@ -110,7 +183,8 @@ def main():
     network, class_names, class_colors = darknet.load_network(
         args.config_file,
         args.data_file,
-        args.weights
+        args.weights,
+        batch_size=args.batch_size
     )
 
     images = load_images(args.input)
@@ -141,4 +215,6 @@ def main():
 
 
 if __name__ == "__main__":
+    # unconmment next line for an example of batch processing
+    # batch_detection_example()
     main()

--- a/darknet_images.py
+++ b/darknet_images.py
@@ -99,7 +99,7 @@ def save_annotations(name, image, detections, class_names):
         for label, confidence, bbox in detections:
             x, y, w, h = convert2relative(image, bbox)
             label = class_names.index(label)
-            f.write("{} {:.4f} {:.4f} {:.4f} {:.4f}\n".format(label, x, y, w, h))
+            f.write("{} {:.4f} {:.4f} {:.4f} {:.4f} {:.4f}\n".format(label, x, y, w, h, confidence))
 
 
 def main():

--- a/darknet_video.py
+++ b/darknet_video.py
@@ -1,9 +1,12 @@
+from ctypes import *
+import random
 import os
 import cv2
 import time
 import darknet
 import argparse
-import random
+from threading import Thread, enumerate
+from queue import Queue
 
 
 def parser():
@@ -27,6 +30,17 @@ def parser():
     return parser.parse_args()
 
 
+def str2int(video_path):
+    """
+    argparse returns and string althout webcam uses int (0, 1 ...)
+    Cast to int if needed
+    """
+    try:
+        return int(video_path)
+    except ValueError:
+        return video_path
+
+
 def check_arguments_errors(args):
     assert 0 < args.thresh < 1, "Threshold should be a float between zero and one (non-inclusive)"
     if not os.path.exists(args.config_file):
@@ -39,67 +53,82 @@ def check_arguments_errors(args):
         raise(ValueError("Invalid video path {}".format(os.path.abspath(args.input))))
 
 
-def str2int(video_path):
-    """
-    argparse returns and string althout webcam uses int (0, 1 ...)
-    Cast to int if needed
-    """
-    try:
-        return int(video_path)
-    except ValueError:
-        return video_path
-
-
 def set_saved_video(input_video, output_video, size):
     fourcc = cv2.VideoWriter_fourcc(*"MJPG")
     fps = int(input_video.get(cv2.CAP_PROP_FPS))
-    video = cv2.VideoWriter(output_video, fourcc, fps, size,)
+    video = cv2.VideoWriter(output_video, fourcc, fps, size)
     return video
 
 
-def main():
-    args = parser()
-    check_arguments_errors(args)
-    random.seed(3)  # deterministic bbox colors
-
-    network, class_names, class_colors = darknet.load_network(
-        args.config_file,
-        args.data_file,
-        args.weights
-    )
-    # Darknet doesn't accept numpy images.
-    # Create one with image we reuse for each detect
-    width = darknet.network_width(network)
-    height = darknet.network_height(network)
-    darknet_image = darknet.make_image(width, height, 3)
-
-    input_path = str2int(args.input)
-    cap = cv2.VideoCapture(input_path)
-    video = set_saved_video(cap, args.out_filename, (width, height))
-
+def video_capture(frame_queue, darknet_image_queue):
     while cap.isOpened():
-        prev_time = time.time()
         ret, frame = cap.read()
         if not ret:
             break
         frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         frame_resized = cv2.resize(frame_rgb, (width, height),
                                    interpolation=cv2.INTER_LINEAR)
+        frame_queue.put(frame_resized)
         darknet.copy_image_from_bytes(darknet_image, frame_resized.tobytes())
+        darknet_image_queue.put(darknet_image)
+    cap.release()
+
+
+def inference(darknet_image_queue, detections_queue, fps_queue):
+    while cap.isOpened():
+        darknet_image = darknet_image_queue.get()
+        prev_time = time.time()
         detections = darknet.detect_image(network, class_names, darknet_image, thresh=args.thresh)
-        image = darknet.draw_boxes(detections, frame_resized, class_colors)
-        image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-        if args.out_filename is not None:
-            video.write(image)
+        detections_queue.put(detections)
         fps = int(1/(time.time() - prev_time))
+        fps_queue.put(fps)
         print("FPS: {}".format(fps))
         darknet.print_detections(detections, args.ext_output)
-        if not args.dont_show:
-            cv2.imshow('Inference', image)
-            cv2.waitKey(fps)
+    cap.release()
+
+
+def drawing(frame_queue, detections_queue, fps_queue):
+    random.seed(3)  # deterministic bbox colors
+    video = set_saved_video(cap, args.out_filename, (width, height))
+    while cap.isOpened():
+        frame_resized = frame_queue.get()
+        detections = detections_queue.get()
+        fps = fps_queue.get()
+        if frame_resized is not None:
+            image = darknet.draw_boxes(detections, frame_resized, class_colors)
+            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+            if args.out_filename is not None:
+                video.write(image)
+            if not args.dont_show:
+                cv2.imshow('Inference', image)
+            if cv2.waitKey(fps) == 27:
+                break
     cap.release()
     video.release()
+    cv2.destroyAllWindows()
 
 
-if __name__ == "__main__":
-    main()
+if __name__ == '__main__':
+    frame_queue = Queue()
+    darknet_image_queue = Queue(maxsize=1)
+    detections_queue = Queue(maxsize=1)
+    fps_queue = Queue(maxsize=1)
+
+    args = parser()
+    check_arguments_errors(args)
+    network, class_names, class_colors = darknet.load_network(
+            args.config_file,
+            args.data_file,
+            args.weights,
+            batch_size=1
+        )
+    # Darknet doesn't accept numpy images.
+    # Create one with image we reuse for each detect
+    width = darknet.network_width(network)
+    height = darknet.network_height(network)
+    darknet_image = darknet.make_image(width, height, 3)
+    input_path = str2int(args.input)
+    cap = cv2.VideoCapture(input_path)
+    Thread(target=video_capture, args=(frame_queue, darknet_image_queue)).start()
+    Thread(target=inference, args=(darknet_image_queue, detections_queue, fps_queue)).start()
+    Thread(target=drawing, args=(frame_queue, detections_queue, fps_queue)).start()

--- a/darknet_video.py
+++ b/darknet_video.py
@@ -73,7 +73,7 @@ def main():
     darknet_image = darknet.make_image(width, height, 3)
 
     cap = cv2.VideoCapture(args.input)
-    video = set_video(args.input, args.output_file, (width, height))
+    video = set_video(args.input, args.out_filename, (width, height))
 
     while cap.isOpened():
         prev_time = time.time()
@@ -87,7 +87,7 @@ def main():
         detections = darknet.detect_image(network, class_names, darknet_image, thresh=args.thresh)
         image = darknet.draw_boxes(detections, frame_resized, class_colors)
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-        if args.output_file is not None:
+        if args.out_filename is not None:
             video.write(image)
         fps = int(1/(time.time() - prev_time))
         print("FPS: {}".format(fps))

--- a/darknet_video.py
+++ b/darknet_video.py
@@ -10,7 +10,7 @@ def parser():
     parser = argparse.ArgumentParser(description="YOLO Object Detection")
     parser.add_argument("--input", type=str, default=0,
                         help="video source. If empty, uses webcam 0 stream")
-    parser.add_argument("--output_file", type=str, default="",
+    parser.add_argument("--out_filename", type=str, default="",
                         help="inference video name. Not saved if empty")
     parser.add_argument("--weights", default="yolov4.weights",
                         help="yolo weights path")

--- a/darknet_video.py
+++ b/darknet_video.py
@@ -35,24 +35,25 @@ def check_arguments_errors(args):
         raise(ValueError("Invalid weight path {}".format(os.path.abspath(args.weights))))
     if not os.path.exists(args.data_file):
         raise(ValueError("Invalid data file path {}".format(os.path.abspath(args.data_file))))
-    if args.input and not os.path.exists(args.input):
-        raise(ValueError("Invalid image path {}".format(os.path.abspath(args.input))))
+    if str2int(args.input) == str and not os.path.exists(args.input):
+        raise(ValueError("Invalid video path {}".format(os.path.abspath(args.input))))
 
 
-def set_video(input_video, output_video, size, fps=15):
+def str2int(video_path):
     """
-    Setup input and ouput (saved) video objects
-        args:
-            input_video (str): path to video, or webcam device number
-            output_video (str): inference video name to be saved
-            fps: frames per second for saved video (adjust this number for
-            player speed)
-        returns:
-            cap: cv2 input video object
-            video: cv2 output video object
+    argparse returns and string althout webcam uses int (0, 1 ...)
+    Cast to int if needed
     """
+    try:
+        return int(video_path)
+    except ValueError:
+        return video_path
+
+
+def set_saved_video(input_video, output_video, size):
     fourcc = cv2.VideoWriter_fourcc(*"MJPG")
-    video = cv2.VideoWriter(output_video, fourcc, fps, size)
+    fps = int(input_video.get(cv2.CAP_PROP_FPS))
+    video = cv2.VideoWriter(output_video, fourcc, fps, size,)
     return video
 
 
@@ -72,8 +73,9 @@ def main():
     height = darknet.network_height(network)
     darknet_image = darknet.make_image(width, height, 3)
 
-    cap = cv2.VideoCapture(args.input)
-    video = set_video(args.input, args.out_filename, (width, height))
+    input_path = str2int(args.input)
+    cap = cv2.VideoCapture(input_path)
+    video = set_saved_video(cap, args.out_filename, (width, height))
 
     while cap.isOpened():
         prev_time = time.time()


### PR DESCRIPTION
First of all, thank for this well maintained repo, and kudos for the YOLOv4 step and its paper. It was written in a very instructive way.

## Why this pull request
Many useful features implemented in darknet C code are not accessed by the python wrapper, and the ones that can be used haven't the same commands. At the end, this situation becomes in a switching between both languages, and some incompatibilities with python MLOps tools.

## Features

* Added **colors for bboxes**, one for each class.
![Bbox colors](https://i.imgur.com/AWBiuCx.png)

* Added **command parser**.  At the moment, parameters for python scripts are handcoded. With this parser, we can invoke darknet like the README documentation:
```
python darknet_video.py --data_file cfg/coco.data --config_file cfg/yolov4.cfg --weights yolov4.weights --thresh 0.7 --input test.mp4 
```

* Print **bbox coordinates** with `--ext_output`
```
python darknet_video.py --weights yolov4.weights --input test.mp4 --ext_output
```

* Use `--dont_show` to prevent inference window. For headless systems:
```
python darknet_video.py --weights yolov4.weights --input test.mp4 --dont_show
```

* darknet as a module. Modules are the normal way to work with python, because of that, `darknet.py` is preserved, (and, as before, it doesn't need opencv installation). Examples are splited into `darknet_video.py` and `darknet_images.py` (which need opencv).

* **Save result videofile** video with `--out_filename`
```
python darknet_video.py --weights yolov4.weights --input test.mp4 --out_filename res.avi
```

* `darknet_video.py` can proccess **net-videocam** streams like `http://IP:PORT/xxxx.mjpg`

* `darnet_images.py`, like C code, accepts **path to and image** or a **txt file** with a list of them. If a **path to a folder** is given, it reads all jpg, png and jpeg images in it. If there is no path, it **loops asking** for one:
```
python darknet_images.py --weights yolov4.weights 
```
or
```
python darknet_images.py --weights yolov4.weights --input dog.jpg
```

* **Pseudolabeling** can be used in same way as in the README:
```
python darknet_images.py --weights yolov4.weights --input images/images_list.txt --save_labels
```

* Code cleaned: removed global variables, used functions in a proper way, and more readable code for less comments.


## TODO
* Code is not tested in Windows. I understand that this is a must :red_circle: 
* `AVG_fps` print is not implement.
* Bbox text is not resized with the its bbox size.
* An input parameter for desired class colors could be useful?
* Save inference images command (like `--output_file` video option)?


## My sin
This pull request is an only big commit :shit: I know, this is not the way to do things, but an unexpected docker shutdown removed all. A backup of the files survived :muscle:, but not the git folder. Sorry.

Hope it helps to anyone. If changes in the code are needed, feel free to ask.