### PR TITLE
add: rgb_to_image helper function

### DIFF
--- a/include/darknet.h
+++ b/include/darknet.h
@@ -983,6 +983,7 @@ LIB_API image letterbox_image(image im, int w, int h);
 LIB_API void rgbgr_image(image im);
 LIB_API image make_image(int w, int h, int c);
 LIB_API image load_image_color(char *filename, int w, int h);
+LIB_API image rgb_to_image(int w, int h, int c, unsigned char *data);
 LIB_API void free_image(image m);
 LIB_API image crop_image(image im, int dx, int dy, int w, int h);
 LIB_API image resize_min(image im, int min);

--- a/src/image.c
+++ b/src/image.c
@@ -823,7 +823,7 @@ image float_to_image_scaled(int w, int h, int c, float *data)
 image rgb_to_image(int w, int h, int c, unsigned char* data)
 {
   image out = make_empty_image(w,h,c);
-  out.data = (float*)malloc(w*h*c*sizeof(float));
+  out.data = (float*)xmalloc(w*h*c*sizeof(float));
 
   int step = w*c;
   int i, j, k;

--- a/src/image.c
+++ b/src/image.c
@@ -820,6 +820,26 @@ image float_to_image_scaled(int w, int h, int c, float *data)
     return out;
 }
 
+image rgb_to_image(int w, int h, int c, unsigned char* data)
+{
+  image out = make_empty_image(w,h,c);
+  out.data = malloc(w*h*c*sizeof(float));
+
+  int step = w*c;
+  int i, j, k;
+  float mult = 1/255.;
+
+  for(i = 0; i < h; ++i){
+    for(k = 0; k < c; ++k){
+      for(j = 0; j < w; ++j){
+        out.data[k*w*h + i*w + j] = data[i*step + j*c + k] * mult;
+      }
+    }
+  }
+
+  return out;
+}
+
 image float_to_image(int w, int h, int c, float *data)
 {
     image out = make_empty_image(w,h,c);

--- a/src/image.c
+++ b/src/image.c
@@ -823,7 +823,7 @@ image float_to_image_scaled(int w, int h, int c, float *data)
 image rgb_to_image(int w, int h, int c, unsigned char* data)
 {
   image out = make_empty_image(w,h,c);
-  out.data = malloc(w*h*c*sizeof(float));
+  out.data = (float*)malloc(w*h*c*sizeof(float));
 
   int step = w*c;
   int i, j, k;


### PR DESCRIPTION
useful for FFI interfaces where GC might free
original image data at any time