### PR TITLE
Remove omp in mean_arrays

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -579,12 +579,10 @@ void mean_arrays(float **a, int n, int els, float *avg)
     int j;
     memset(avg, 0, els*sizeof(float));
     for(j = 0; j < n; ++j){
-        #pragma omp parallel for
         for(i = 0; i < els; ++i){
             avg[i] += a[j][i];
         }
     }
-    #pragma omp parallel for
     for(i = 0; i < els; ++i){
         avg[i] /= n;
     }


### PR DESCRIPTION
I have better performance without omp when I try yolov4 with "uselib". (15 FPS with, 25 without)

Besides, maybe we should replace this code:
https://github.com/AlexeyAB/darknet/blob/e6469eb071521a4ff5be8c0e9cceb524d0a65a95/src/yolo_v2_class.cpp#L304-L309
with this one (as you did for demo.c):
https://github.com/AlexeyAB/darknet/blob/ccafff912bd42728aa873be7b4c7add2366858a8/src/demo.c#L104-L108
