### PR TITLE
.so file path fix

### DIFF
--- a/darknet.py
+++ b/darknet.py
@@ -124,7 +124,7 @@ if os.name == "nt":
             lib = CDLL(winGPUdll, RTLD_GLOBAL)
             print("Environment variables indicated a CPU run, but we didn't find `"+winNoGPUdll+"`. Trying a GPU run anyway.")
 else:
-    lib = CDLL("./libdarknet.so", RTLD_GLOBAL)
+    lib = CDLL("./libdark.so", RTLD_GLOBAL)
 lib.network_width.argtypes = [c_void_p]
 lib.network_width.restype = c_int
 lib.network_height.argtypes = [c_void_p]


### PR DESCRIPTION
After builiding darknet using LIB_SO = 1, the libso file name is 'libdark.so'. So, the changing the name of .so file from 'libdarknet.so' to 'libdark.so' needs to be done in darknet.py