### PR TITLE
Explicitly install CUDA version 10.2 in win-{vcpkg,intlibs}-cuda actions

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -405,7 +405,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: 'Install CUDA'
       run: |
-        choco install cuda -y
+        choco install cuda --version=10.2.89.20191206 -y
         $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
         Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
         refreshenv
@@ -530,7 +530,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: 'Install CUDA'
       run: |
-        choco install cuda -y
+        choco install cuda --version=10.2.89.20191206 -y
         $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
         Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
         refreshenv


### PR DESCRIPTION
Chocolatey installs the latest version by default, but Darknet isn't yet compatible with CUDA 11. Explicitly install the most recent CUDA 10.2 release instead.

Fixes #5959.

Signed-off-by: Juuso Alasuutari <juuso.alasuutari@gmail.com>