### PR TITLE
Add Deeplabel annotation tool to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,7 @@ Different tools for marking objects in images:
 3. in Python: https://github.com/Cartucho/OpenLabeling
 4. in C++: https://www.ccoderun.ca/darkmark/
 5. in JavaScript: https://github.com/opencv/cvat
+6. in C++: https://github.com/jveitchmichaelis/deeplabel
 
 
 ## How to use Yolo as DLL and SO libraries


### PR DESCRIPTION
Hi, I'm the author of deeplabel, an open source bounding box annotation tool. I saw some other labelling tools are in the readme and hope you'd consider adding this one as well - it's a GUI app written in C++, binaries are provided for Windows and Mac, and it compiles fine on Linux.

https://github.com/jveitchmichaelis/deeplabel

Deeplabel imports from and exports directly to darknet format and also allows users to load darknet weights for automatically labelling an image dataset - though this currently only works up to yolov3 pending support in OpenCV. We use it in our research group for easily labeling video sequences prior to training with darknet. I'm hoping in the near future to also add support for adding train support via a user-supplied darknet binary, or at least generating the config files automatically.

Thanks for the consideration!
