### PR TITLE
Fix '"/*" within comment' warnings; remove instances of '//*'

### DIFF
--- a/src/gemm.c
+++ b/src/gemm.c
@@ -1031,7 +1031,7 @@ void convolution_2d(int w, int h, int ksize, int n, int c, int pad, int stride,
     }
 
     //for (i = 0; i < w*h*c; i += 8) {
-        //*((__m256*)&input[i]) = _mm256_and_ps(*((__m256*)&input[i]), _mm256_castsi256_ps(all256_sing1));
+        //(*(__m256*)&input[i]) = _mm256_and_ps(*((__m256*)&input[i]), _mm256_castsi256_ps(all256_sing1));
     //}
 
 
@@ -1124,7 +1124,7 @@ void convolution_2d(int w, int h, int ksize, int n, int c, int pad, int stride,
 
                     //__m256 out = *((__m256*)&output[output_index]);
                     //out = _mm256_add_ps(out, sum256);
-                    //*((__m256*)&output[output_index]) = out;
+                    //(*(__m256*)&output[output_index]) = out;
                     *((__m256*)&output[output_index]) = sum256;
 
                     //_mm256_storeu_ps(&C[i*ldc + j], result256);

--- a/src/im2col_kernels.cu
+++ b/src/im2col_kernels.cu
@@ -60,7 +60,7 @@ __global__ void im2col_gpu_kernel(const int n, const float* data_im,
                     data_im_ptr[i * width + j] : 0;
 
                 //data_im[(channel_in * height + h_in) * width + w_in + i * width + j];
-                //*data_col_ptr = data_im_ptr[ii * width + jj];
+                //(*data_col_ptr) = data_im_ptr[ii * width + jj];
 
                 data_col_ptr += height_col * width_col;
             }
@@ -122,7 +122,7 @@ __global__ void im2col_align_gpu_kernel(const int n, const float* data_im,
                 *data_col_ptr = val;
                 //tmp_s[0] = val;
 
-                //*data_col_ptr = (h >= 0 && w >= 0 && h < height && w < width) ?
+                //(*data_col_ptr) = (h >= 0 && w >= 0 && h < height && w < width) ?
                 //    data_im_ptr[i * width + j] : 0;
 
                 //float src_val = (h >= 0 && w >= 0 && h < height && w < width) ? data_im_ptr[i * width + j] : 0;
@@ -178,11 +178,11 @@ __global__ void im2col_align_gpu_kernel(const int n, const float* data_im,
                 int out_index = (channel_out + i*ksize + j) * bit_align + pre_out_index;// h_out * width_col + w_out;
                 data_col[out_index] = val;
 
-                //*data_col_ptr = val;
+                //(*data_col_ptr) = val;
                 //dst_s[threadIdx.x] = val;
                 //tmp_s[0] = val;
 
-                //*data_col_ptr = (h >= 0 && w >= 0 && h < height && w < width) ?
+                //(*data_col_ptr) = (h >= 0 && w >= 0 && h < height && w < width) ?
                 //    data_im_ptr[i * width + j] : 0;
 
                 //float src_val = (h >= 0 && w >= 0 && h < height && w < width) ? data_im_ptr[i * width + j] : 0;
@@ -1175,7 +1175,7 @@ __global__ void gemm_nn_custom_bin_mean_transposed_gpu_kernel(int M, int N, int 
 
     //if (i_cur < M && (index % N == 0 || threadIdx.x == 0)) {
     //for (int k = 0; k < K; k += 64) {   // l.size*l.size*l.c - one filter size [27 - 9216]
-    //*((uint64_t *)(A_s + (local_i*lda + k) / 8)) = *((uint64_t *)(A + (i_cur*lda + k) / 8));    // weights
+    //(*(uint64_t *)(A_s + (local_i*lda + k) / 8)) = *((uint64_t *)(A + (i_cur*lda + k) / 8));    // weights
     //  }
     //}
 

--- a/src/yolo_layer.c
+++ b/src/yolo_layer.c
@@ -597,7 +597,7 @@ void forward_yolo_layer(const layer l, network_state state)
     if (count == 0) count = 1;
     if (class_count == 0) class_count = 1;
 
-    //*(l.cost) = pow(mag_array(l.delta, l.outputs * l.batch), 2);
+    //(*l.cost) = pow(mag_array(l.delta, l.outputs * l.batch), 2);
     //printf("Region %d Avg IOU: %f, Class: %f, Obj: %f, No Obj: %f, .5R: %f, .75R: %f,  count: %d\n", state.index, avg_iou / count, avg_cat / class_count, avg_obj / count, avg_anyobj / (l.w*l.h*l.n*l.batch), recall / count, recall75 / count, count);
 
     int stride = l.w*l.h;


### PR DESCRIPTION
This change silences a compiler warning emitted by gcc with `-Wall`. It also works around a highlighting issue which is caused by broken comment syntax parsing in at least one editor[1].

No functional changes.

[1] https://imgur.com/a/YA5WCtx

Signed-off-by: Juuso Alasuutari <juuso.alasuutari@gmail.com>