### PR TITLE
Fix anchors for yolov4-tiny

### DIFF
--- a/cfg/yolov4-tiny.cfg
+++ b/cfg/yolov4-tiny.cfg
@@ -264,7 +264,7 @@ filters=255
 activation=linear
 
 [yolo]
-mask = 1,2,3
+mask = 0,1,2
 anchors = 10,14,  23,27,  37,58,  81,82,  135,169,  344,319
 classes=80
 num=6


### PR DESCRIPTION
The first anchor with index 0 was ignored in the second yolo layer for yolov4-tiny which results in a decrease of map of min. -25%.  