### PR TITLE
Fixed incorrect calculation of mAP for -points 0 (for own dataset) issue #6040

### DIFF
--- a/src/detector.c
+++ b/src/detector.c
@@ -1256,8 +1256,8 @@ float validate_detector_map(char *datacfg, char *cfgfile, char *weightfile, floa
             //add remaining area of PR curve when recall isn't 0 at rank1
             if(pr[i][0].recall!=0)
             {
-                delta_recall=last_recall;//last_recall-0;
-                avg_precision += delta_recall * last_precision;
+                //delta_recall=last_recall-0;
+                avg_precision += last_recall * last_precision;
             }
         }
         // MSCOCO - 101 Recall-points, PascalVOC - 11 Recall-points

--- a/src/detector.c
+++ b/src/detector.c
@@ -1259,6 +1259,7 @@ float validate_detector_map(char *datacfg, char *cfgfile, char *weightfile, floa
                 //delta_recall=last_recall-0;
                 avg_precision += last_recall * last_precision;
             }
+            printf("class_id = %d, point = %d, cur_recall = %.4f, cur_precision = %.4f \n", i, point, last_recall, last_precision);
         }
         // MSCOCO - 101 Recall-points, PascalVOC - 11 Recall-points
         else

--- a/src/detector.c
+++ b/src/detector.c
@@ -1253,6 +1253,12 @@ float validate_detector_map(char *datacfg, char *cfgfile, char *weightfile, floa
 
                 avg_precision += delta_recall * last_precision;
             }
+            //add remaining area of PR curve when recall isn't 0 at rank1
+            if(pr[i][0].recall!=0)
+            {
+                delta_recall=last_recall;//last_recall-0;
+                avg_precision += delta_recall * last_precision;
+            }
         }
         // MSCOCO - 101 Recall-points, PascalVOC - 11 Recall-points
         else


### PR DESCRIPTION
**The aP and mAP were being calculated wrong as mentioned in this issue:** [link](https://github.com/AlexeyAB/darknet/issues/6040)

I have added code to calculate and add the area of part of AUC (under PR) which was not being added in the case when the recall was non-zero for the Rank-1 detection.(mainly seen in test set with less images.) 

**So the area of curve between the: rank-1 detection with non-zero recall and point with zero recall is now calculated.** which wasn't being calculated earlier.

To check the problem and reason of that problem....check the issue where I have explained all in detail with proof. [link](https://github.com/AlexeyAB/darknet/issues/6040) 