### PR TITLE
Fix member initialization ordering

### DIFF
--- a/include/yolo_v2_class.hpp
+++ b/include/yolo_v2_class.hpp
@@ -851,8 +851,7 @@ public:
 
 
     track_kalman_t(int _max_objects = 1000, int _min_frames = 3, float _max_dist = 40, cv::Size _img_size = cv::Size(10000, 10000)) :
-        max_objects(_max_objects), min_frames(_min_frames), max_dist(_max_dist), img_size(_img_size),
-        track_id_counter(0)
+        track_id_counter(0), max_objects(_max_objects), min_frames(_min_frames), max_dist(_max_dist), img_size(_img_size)
     {
         kalman_vec.resize(max_objects);
         track_id_state_id_time.resize(max_objects);

--- a/src/yolo_console_dll.cpp
+++ b/src/yolo_console_dll.cpp
@@ -398,7 +398,7 @@ int main(int argc, char *argv[])
                     bool exit_flag;
                     cv::Mat zed_cloud;
                     std::queue<cv::Mat> track_optflow_queue;
-                    detection_data_t() : exit_flag(false), new_detection(false) {}
+                    detection_data_t() : new_detection(false), exit_flag(false) {}
                 };
 
                 const bool sync = detection_sync; // sync data exchange


### PR DESCRIPTION
Clears "-Wreorder" build warnings.

Signed-off-by: Juuso Alasuutari <juuso.alasuutari@gmail.com>