### PR TITLE
Use predefined constants

### DIFF
--- a/darknet_video.py
+++ b/darknet_video.py
@@ -81,8 +81,8 @@ def YOLO():
             pass
     #cap = cv2.VideoCapture(0)
     cap = cv2.VideoCapture("test.mp4")
-    cap.set(3, 1280)
-    cap.set(4, 720)
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH, 1280)
+    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 720)
     out = cv2.VideoWriter(
         "output.avi", cv2.VideoWriter_fourcc(*"MJPG"), 10.0,
         (darknet.network_width(netMain), darknet.network_height(netMain)))


### PR DESCRIPTION
It makes the arguments readable in [set()](https://docs.opencv.org/4.3.0/d8/dfe/classcv_1_1VideoCapture.html#a8c6d8c2d37505b5ca61ffd4bb54e9a7c) .

More info: [VideoCaptureProperties](https://docs.opencv.org/4.3.0/d4/d15/group__videoio__flags__base.html#gaeb8dd9c89c10a5c63c139bf7c4f5704d)