### PR TITLE
Fix yolo mask in yolov4-tiny.cfg

### DIFF
--- a/cfg/yolov4-tiny.cfg
+++ b/cfg/yolov4-tiny.cfg
@@ -264,7 +264,7 @@ filters=255
 activation=linear
 
 [yolo]
-mask = 1,2,3
+mask = 0,1,2
 anchors = 10,14,  23,27,  37,58,  81,82,  135,169,  344,319
 classes=80
 num=6


### PR DESCRIPTION
Please correct me if I'm wrong, but I believe the `mask` property of the second `yolo` layer in `yolov4-tiny.cfg` has the wrong value. It looks like `yolov4-tiny-custom.cfg` has the correct value but this file does not.