### PR TITLE
fixed Makefile for CUDA 11.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,10 @@ ZED_CAMERA_v2_8=0
 USE_CPP=0
 DEBUG=0
 
-ARCH= -gencode arch=compute_30,code=sm_30 \
-      -gencode arch=compute_35,code=sm_35 \
+# It looks like Kepler(generic) support discontinued after CUDA 11.0.
+#ARCH= -gencode arch=compute_30,code=sm_30
+
+ARCH= -gencode arch=compute_35,code=sm_35 \
       -gencode arch=compute_50,code=[sm_50,compute_50] \
       -gencode arch=compute_52,code=[sm_52,compute_52] \
 	    -gencode arch=compute_61,code=[sm_61,compute_61]


### PR DESCRIPTION
Moved Kepler(generic) support to optional on makefile.

It looks lile Kepler(generic) support discontinued after CUDA 11.0.
https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#virtual-architecture-feature-list

Related #6361 .