### PR TITLE
Add free_network_ptr Support for Darknet in Python

### DIFF
--- a/darknet.py
+++ b/darknet.py
@@ -188,6 +188,10 @@ load_net_custom = lib.load_network_custom
 load_net_custom.argtypes = [c_char_p, c_char_p, c_int, c_int]
 load_net_custom.restype = c_void_p
 
+free_network_ptr = lib.free_network_ptr
+free_network_ptr.argtypes = [c_void_p]
+free_network_ptr.restype = c_void_p
+
 do_nms_obj = lib.do_nms_obj
 do_nms_obj.argtypes = [POINTER(DETECTION), c_int, c_int, c_float]
 


### PR DESCRIPTION
Hi @AlexeyAB ,

In the use cases of running darknet for inference in Python environment, especially in Kaggle GPU notebooks, it is essential to get the flexibility of freeing CUDA memory from the loaded darknet models while generating ensembles.
I noticed that there has been a `free_network_ptr` function defined in the darknet C code that can be utilized to avoid CUDA out-of-memory issues.

Here is a PR to merge this part of support into `darknet.py` that I've already tested it on [a Kaggle GPU notebook](https://www.kaggle.com/markpeng/yolov4-infer-gpu-v3-tta-fold2-pseudo-label-final/data?scriptVersionId=40120067), thanks!