### PR TITLE
Update darknet.py to run outside the darknet folder

### DIFF
--- a/darknet.py
+++ b/darknet.py
@@ -11,6 +11,7 @@ On a GPU system, you can force CPU evaluation by any of:
 - Set global variable DARKNET_FORCE_CPU to True
 - Set environment variable CUDA_VISIBLE_DEVICES to -1
 - Set environment variable "FORCE_CPU" to "true"
+- Set environment variable "DARKNET_PATH" to path darknet lib .so (for Linux)
 
 Directly viewing or returning bounding-boxed images requires scikit-image to be installed (`pip install scikit-image`)
 
@@ -219,7 +220,9 @@ if os.name == "nt":
             lib = CDLL(winGPUdll, RTLD_GLOBAL)
             print("Environment variables indicated a CPU run, but we didn't find {}. Trying a GPU run anyway.".format(winNoGPUdll))
 else:
-    lib = CDLL("./libdarknet.so", RTLD_GLOBAL)
+    lib = CDLL(os.path.join(
+        os.environ.get('DARKNET_PATH', './'),
+        "libdarknet.so"), RTLD_GLOBAL)
 lib.network_width.argtypes = [c_void_p]
 lib.network_width.restype = c_int
 lib.network_height.argtypes = [c_void_p]


### PR DESCRIPTION
# Example code
```python
import os
import sys

os.environ['DARKNET_PATH'] = '/usr/local/darknet'
sys.path.append(os.environ['DARKNET_PATH'])

import darknet


def main():
    network, class_names, class_colors = darknet.load_network(
        '../nscan-train/data/cfg/yolov4-tiny-3l-numbers-12.cfg',
        '../nscan-train/data/numbers.data',
        './data/weights/numbers/yolov4-tiny-3l-numbers-12_last.weights',
        batch_size=1
    )


if __name__ == '__main__':
    main()
```