### PR TITLE
Improve model loading performance for detect

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -1240,12 +1240,14 @@ void fuse_conv_batchnorm(network net)
                 {
                     l->biases[f] = l->biases[f] - (double)l->scales[f] * l->rolling_mean[f] / (sqrt((double)l->rolling_variance[f] + .00001));
 
+                    double precomputed = l->scales[f] / (sqrt((double)l->rolling_variance[f] + .00001));
+
                     const size_t filter_size = l->size*l->size*l->c / l->groups;
                     int i;
                     for (i = 0; i < filter_size; ++i) {
                         int w_index = f*filter_size + i;
 
-                        l->weights[w_index] = (double)l->weights[w_index] * l->scales[f] / (sqrt((double)l->rolling_variance[f] + .00001));
+                        l->weights[w_index] *= precomputed;
                     }
                 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -38,7 +38,6 @@ void *xcalloc(size_t nmemb, size_t size) {
     if(!ptr) {
         calloc_error();
     }
-    memset(ptr, 0, nmemb * size);
     return ptr;
 }
 


### PR DESCRIPTION
We use darknet at Observa in a production environment and these couple of changes improve model loading performance by around 0.9 seconds.

Changes
- Move part of a large multiplication outside of innermost loop in `fuse_conv_batchnorm`
- Remove unnecessary memset(0) after calloc in `xcalloc`