### PR TITLE
Update darknet_images.py

### DIFF
--- a/darknet_images.py
+++ b/darknet_images.py
@@ -139,7 +139,7 @@ def convert2relative(image, bbox):
     YOLO format use relative coordinates for annotation
     """
     x, y, w, h = bbox
-    width, height, _ = image.shape
+    height, width, _ = image.shape
     return x/width, y/height, w/width, h/height
 
 


### PR DESCRIPTION
142line：
width, height, _ = image.shape
The height and width are reversed, resulting in the label being greater than 1
Revised to：
height, width, _ = image.shape