### PR TITLE
Support label image filename with multiple extension.

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -239,12 +239,23 @@ void trim(char *str)
     free(buffer);
 }
 
+char *strlaststr(char *haystack, char *needle)
+{
+    char *p = strstr(haystack, needle), *r = NULL;
+    while (p != NULL)
+    {
+        r = p;
+        p = strstr(p + 1, needle);
+    }
+    return r;
+}
+
 void find_replace_extension(char *str, char *orig, char *rep, char *output)
 {
     char* buffer = (char*)calloc(8192, sizeof(char));
 
     sprintf(buffer, "%s", str);
-    char *p = strstr(buffer, orig);
+    char *p = strlaststr(buffer, orig);
     int offset = (p - buffer);
     int chars_from_end = strlen(buffer) - offset;
     if (!p || chars_from_end != strlen(orig)) {  // Is 'orig' even in 'str' AND is 'orig' found at the end of 'str'?


### PR DESCRIPTION
Fix a bug when filename contains multiple extension, the bbox .txt filename cannot be generated.