### PR TITLE
Fix: Python example API that caused Memory leak.

### DIFF
--- a/darknet_images.py
+++ b/darknet_images.py
@@ -111,6 +111,7 @@ def image_detection(image_path, network, class_names, class_colors, thresh):
 
     darknet.copy_image_from_bytes(darknet_image, image_resized.tobytes())
     detections = darknet.detect_image(network, class_names, darknet_image, thresh=thresh)
+    darknet.free_image(darknet_image)
     image = darknet.draw_boxes(detections, image_resized, class_colors)
     return cv2.cvtColor(image, cv2.COLOR_BGR2RGB), detections
 

--- a/darknet_video.py
+++ b/darknet_video.py
@@ -84,6 +84,7 @@ def inference(darknet_image_queue, detections_queue, fps_queue):
         fps_queue.put(fps)
         print("FPS: {}".format(fps))
         darknet.print_detections(detections, args.ext_output)
+        darknet.free_image(darknet_image)
     cap.release()
 
 


### PR DESCRIPTION
Hi:
  I tested the python API and the memory leak was fast growing, and I checked the darknet.py where I found free_image(), according IMAGE structure, I added the free function after detect_image() to free IMAGE from make_image, and everything was fine!

Thx,
A.H.