### PR TITLE
fix too many or too few labels error on Linux/Mac/Windows when trainning

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -525,10 +525,18 @@ data load_data_captcha_encode(char **paths, int n, int m, int w, int h)
 void fill_truth(char *path, char **labels, int k, float *truth)
 {
     int i;
+    char *filename = "";
+    for(i = strlen(path) - 1; i >= 0; --i) {
+    	if (path[i] == '/' || path[i] == '\\') {
+    		filename = (char*)malloc(strlen(path + i) + 1);
+    		strcpy(filename, path + i + 1);
+    		break;
+    	}
+    }
     memset(truth, 0, k*sizeof(float));
     int count = 0;
     for(i = 0; i < k; ++i){
-        if(strstr(path, labels[i])){
+        if(strstr(filename, labels[i])){
             truth[i] = 1;
             ++count;
         }
@@ -548,10 +556,18 @@ void fill_truth(char *path, char **labels, int k, float *truth)
 void fill_truth_smooth(char *path, char **labels, int k, float *truth, float label_smooth_eps)
 {
     int i;
+    char *filename = "";
+    for(i = strlen(path) - 1; i >= 0; --i) {
+    	if (path[i] == '/' || path[i] == '\\') {
+    		filename = (char*)malloc(strlen(path + i) + 1);
+    		strcpy(filename, path + i + 1);
+    		break;
+    	}
+    }
     memset(truth, 0, k * sizeof(float));
     int count = 0;
     for (i = 0; i < k; ++i) {
-        if (strstr(path, labels[i])) {
+        if (strstr(filename, labels[i])) {
             truth[i] = (1 - label_smooth_eps);
             ++count;
         }

--- a/src/parser.c
+++ b/src/parser.c
@@ -978,10 +978,10 @@ layer parse_shortcut(list *options, size_params params, network net)
 
     for (i = 0; i < n; ++i) {
         int index = layers[i];
-        assert(params.w == net.layers[index].out_w && params.h == net.layers[index].out_h);
+        // assert(params.w == net.layers[index].out_w && params.h == net.layers[index].out_h);
 
         if (params.w != net.layers[index].out_w || params.h != net.layers[index].out_h || params.c != net.layers[index].out_c)
-            fprintf(stderr, " (%4d x%4d x%4d) + (%4d x%4d x%4d) \n",
+            fprintf(stderr, "Downsample here: (%d x %d x %d) + (%d x %d x %d) \n",
                 params.w, params.h, params.c, net.layers[index].out_w, net.layers[index].out_h, params.net.layers[index].out_c);
     }
 


### PR DESCRIPTION
- Some changes in data.c file let user name path to dataset folder freedomly (just use exactly filename to compare with label).

- Some changes in parser.c file fix error assert conflict size when training with resnet backbone because of downsample layer