### PR TITLE
Update darknet_video.py

### DIFF
--- a/darknet_video.py
+++ b/darknet_video.py
@@ -69,6 +69,7 @@ def video_capture(frame_queue, darknet_image_queue):
         frame_resized = cv2.resize(frame_rgb, (width, height),
                                    interpolation=cv2.INTER_LINEAR)
         frame_queue.put(frame_resized)
+        darknet_image = darknet.make_image(width, height, 3)
         darknet.copy_image_from_bytes(darknet_image, frame_resized.tobytes())
         darknet_image_queue.put(darknet_image)
     cap.release()
@@ -110,9 +111,9 @@ def drawing(frame_queue, detections_queue, fps_queue):
 
 if __name__ == '__main__':
     frame_queue = Queue()
-    darknet_image_queue = Queue(maxsize=1)
-    detections_queue = Queue(maxsize=1)
-    fps_queue = Queue(maxsize=1)
+    darknet_image_queue = Queue()
+    detections_queue = Queue()
+    fps_queue = Queue()
 
     args = parser()
     check_arguments_errors(args)
@@ -126,7 +127,6 @@ if __name__ == '__main__':
     # Create one with image we reuse for each detect
     width = darknet.network_width(network)
     height = darknet.network_height(network)
-    darknet_image = darknet.make_image(width, height, 3)
     input_path = str2int(args.input)
     cap = cv2.VideoCapture(input_path)
     Thread(target=video_capture, args=(frame_queue, darknet_image_queue)).start()


### PR DESCRIPTION
The issue:
Previously the output videofile had detections off by 1 frame from the video. 
The reason: 
The `darknet_image` is overwritten in `video_capture` every time it's being created because it sits in the same memory so effectively the `darknet_image_queue` is not working properly

Changes:
- `darknet_image` is created in every iteration of `video_capture` so every new `darknet_image` sits in different memory
- remove limitations on `max_size` of the queue. I believe the limitations were put there to avoid the issue above, but it only made it so the result was off by one frame. Now that that's not an issue there is no reason to have `max_size` for any of the queques