### PR TITLE
fix compatibility with newer clang

### DIFF
--- a/src/gemm.c
+++ b/src/gemm.c
@@ -531,7 +531,7 @@ static inline __int32 _mm256_extract_epi32(__m256i a, const int index) {
 }
 #endif
 
-static inline float _castu32_f32(uint32_t a) {
+static inline float _dn_castu32_f32(uint32_t a) {
     return *((float *)&a);
 }
 
@@ -546,30 +546,30 @@ static inline float _mm256_extract_float32(__m256 a, const int index) {
 #include <smmintrin.h>
 #include <cpuid.h>
 
-static inline float _castu32_f32(uint32_t a) {
+static inline float _dn_castu32_f32(uint32_t a) {
     return *((float *)&a);
 }
 
 static inline float _mm256_extract_float32(__m256 a, const int index) {
     switch(index) {
     case 0:
-      return _castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 0));
+      return _dn_castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 0));
     case 1:
-      return _castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 1));
+      return _dn_castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 1));
     case 2:
-      return _castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 2));
+      return _dn_castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 2));
     case 3:
-      return _castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 3));
+      return _dn_castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 3));
     case 4:
-      return _castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 4));
+      return _dn_castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 4));
     case 5:
-      return _castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 5));
+      return _dn_castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 5));
     case 6:
-      return _castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 6));
+      return _dn_castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 6));
     case 7:
-      return _castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 7));
+      return _dn_castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 7));
     default:
-      return _castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 0));
+      return _dn_castu32_f32(_mm256_extract_epi32(_mm256_castps_si256(a), 0));
     }
 }
 


### PR DESCRIPTION
Fix problems with Xcode 12 on macOS

```
darknet/src/gemm.c:549:21: fatal error: redefinition of '_castu32_f32'
static inline float _castu32_f32(uint32_t a) {
                    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/12.0.0/include/ia32intrin.h:243:1: note: 
      previous definition is here
_castu32_f32(unsigned int __A) {
```

Proper fix would be using the intrinsics defined by the compilers, but since we were already using custom ones, refactoring the name was the preferred solution