### PR TITLE
Free image memory in darknet file

### DIFF
--- a/darknet.py
+++ b/darknet.py
@@ -175,6 +175,7 @@ def detect_image(network, class_names, image, thresh=.5, hier_thresh=.5, nms=.45
     predictions = remove_negatives(detections, class_names, num)
     predictions = decode_detection(predictions)
     free_detections(detections, num)
+    free_image(image)
     return sorted(predictions, key=lambda x: x[1])
 
 

--- a/darknet_images.py
+++ b/darknet_images.py
@@ -111,7 +111,6 @@ def image_detection(image_path, network, class_names, class_colors, thresh):
 
     darknet.copy_image_from_bytes(darknet_image, image_resized.tobytes())
     detections = darknet.detect_image(network, class_names, darknet_image, thresh=thresh)
-    darknet.free_image(darknet_image)
     image = darknet.draw_boxes(detections, image_resized, class_colors)
     return cv2.cvtColor(image, cv2.COLOR_BGR2RGB), detections
 

--- a/darknet_video.py
+++ b/darknet_video.py
@@ -84,7 +84,6 @@ def inference(darknet_image_queue, detections_queue, fps_queue):
         fps_queue.put(fps)
         print("FPS: {}".format(fps))
         darknet.print_detections(detections, args.ext_output)
-        darknet.free_image(darknet_image)
     cap.release()
 
 


### PR DESCRIPTION
Hi @AlexeyAB  @cenit @WongKinYiu

Following the pull request #6668 , It is a good practice to move the `free_image()` call inside `detect_image()`  function in `darknet.py`. This change is suggested as it could lead to errors, as for now you have to call `detect_image()` and then `free_image()` in order to detect and image.

Given way I propose here, users only have to call `detect_image()` to detect and image, reducing code duplication.