### PR TITLE
Added URL link to Darket Data Creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ Different tools for marking objects in images:
 7. in C#: https://github.com/BMW-InnovationLab/BMW-Labeltool-Lite
 8. DL-Annotator for Windows ($30): [url](https://www.microsoft.com/en-us/p/dlannotator/9nsx79m7t8fn?activetab=pivot:overviewtab)
 9. v7labs - the greatest cloud labeling tool ($1.5 per hour): https://www.v7labs.com/
+10. in Java: https://github.com/DanielMartensson/Darknet-Data-Creator/
 
 ## How to use Yolo as DLL and SO libraries
 


### PR DESCRIPTION
I'm adding a URL link to a new software I called Darknet Data Creator. It uses Java to control a USB camera and create images with a desired box. It tool simplifies if you want to create own data instead of download big data that are over 20GB large. 

Yes. It works. Se the URL link.

https://github.com/DanielMartensson/Darknet-Data-Creator