### PR TITLE
remove redundant memory traffic

### DIFF
--- a/src/convolutional_layer.c
+++ b/src/convolutional_layer.c
@@ -717,7 +717,7 @@ convolutional_layer make_convolutional_layer(int batch, int steps, int h, int w,
             if (train) l.bias_updates_gpu = cuda_make_array(l.bias_updates, n);
         }
 
-        l.output_gpu = cuda_make_array(l.output, total_batch*out_h*out_w*n);
+        l.output_gpu = cuda_make_array_init2zero(total_batch*out_h*out_w*n);
         if (train) l.delta_gpu = cuda_make_array(l.delta, total_batch*out_h*out_w*n);
 
         if(binary){
@@ -761,9 +761,9 @@ convolutional_layer make_convolutional_layer(int batch, int steps, int h, int w,
             }
 
             if (train) {
-                l.x_gpu = cuda_make_array(l.output, total_batch*out_h*out_w*n);
+                l.x_gpu = cuda_make_array_init2zero(total_batch*out_h*out_w*n);
 #ifndef CUDNN
-                l.x_norm_gpu = cuda_make_array(l.output, total_batch*out_h*out_w*n);
+                l.x_norm_gpu = cuda_make_array_init2zero( total_batch*out_h*out_w*n);
 #endif  // CUDNN
             }
         }

--- a/src/dark_cuda.c
+++ b/src/dark_cuda.c
@@ -380,6 +380,24 @@ float *cuda_make_array(float *x, size_t n)
     return x_gpu;
 }
 
+float *cuda_make_array_init2zero(size_t n) {
+  float *x_gpu;
+  size_t size = sizeof(float) * n;
+  cudaError_t status = cudaMalloc((void **)&x_gpu, size);
+  // cudaError_t status = cudaMallocManaged((void **)&x_gpu, size,
+  // cudaMemAttachGlobal); status = cudaMemAdvise(x_gpu, size,
+  // cudaMemAdviseSetPreferredLocation, cudaCpuDeviceId);
+  if (status != cudaSuccess)
+    fprintf(stderr, " Try to set subdivisions=64 in your cfg-file. \n");
+  CHECK_CUDA(status);
+  // status = cudaMemcpy(x_gpu, x, size, cudaMemcpyHostToDevice);
+  status =cudaMemset(x_gpu, 0, size);
+  CHECK_CUDA(status);
+  if (!x_gpu)
+    error("Cuda malloc failed\n");
+  return x_gpu;
+}
+
 void **cuda_make_array_pointers(void **x, size_t n)
 {
     void **x_gpu;

--- a/src/dark_cuda.h
+++ b/src/dark_cuda.h
@@ -64,6 +64,7 @@ extern "C" {
     float *cuda_make_array_pinned_preallocated(float *x, size_t n);
     float *cuda_make_array_pinned(float *x, size_t n);
     float *cuda_make_array(float *x, size_t n);
+    float *cuda_make_array_init2zero(size_t n);
     void **cuda_make_array_pointers(void **x, size_t n);
     int *cuda_make_int_array(size_t n);
 	int *cuda_make_int_array_new_api(int *x, size_t n);


### PR DESCRIPTION
In `make_convolutional_layer` function, `l.output` is initialized to 0 by `xcalloc`. Then it is copied to `l.output_gpu`, and conditionally copied to `l.x_gpu` and `l.x_norm_gpu`. 

We can use `cuda_memset` to set these three arrays in gpu side rather than copy all zeros from cpu side. This optimization will save a lot of memory traffic. In my simple test for dog.jpg, it saves about 20% memory copy traffic.