### PR TITLE
Features added to run detection on all images in a folder

### DIFF
--- a/src/detector.c
+++ b/src/detector.c
@@ -1638,9 +1638,39 @@ void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filenam
     }
     int j;
     float nms = .45;    // 0.4F
+
+    //Adding a folder from which a image files can be read
+
+    DIR *folder;
+    struct dirent *entry;
+    int files = 0;
+    folder = opendir("./imagestodetect/");
+
+    if(folder == NULL)
+    {
+        perror("Unable to read directory");
+        return(1);
+    }
+
+
+
+
     while (1) {
+        folder = opendir("./imagestodetect/");
+        while( (entry=readdir(folder)) != NULL)
+        
+        {
+        if((strcmp(entry->d_name,".")==0 || strcmp(entry->d_name,"..")==0 || (entry->d_name) == '.' ) || (strcmp(entry->d_name,"Server_v1.py")==0))
+        {
+         printf(".");
+         sleep(0.5);
+         continue;
+        }
         if (filename) {
-            strncpy(input, filename, 256);
+            char str1[100] = "./imagestodetect/";
+            strcat(str1, entry->d_name);
+            strncpy(input, str1, 256);
+            closedir(folder);
             if (strlen(input) > 0)
                 if (input[strlen(input) - 1] == 0x0d) input[strlen(input) - 1] = 0;
         }
@@ -1650,6 +1680,7 @@ void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filenam
             input = fgets(input, 256, stdin);
             if (!input) break;
             strtok(input, "\n");
+        
         }
         //image im;
         //image sized = load_image_resize(input, net.w, net.h, net.c, &im);

--- a/src/detector.c
+++ b/src/detector.c
@@ -1646,7 +1646,7 @@ void test_detector(char *datacfg, char *cfgfile, char *weightfile, char *filenam
     if(folder == NULL)
     {
         perror("Unable to read directory");
-        return(1);
+        //return(1);
     }
 
     //while( (entry=readdir(folder)) )
@@ -1995,7 +1995,7 @@ void run_detector(int argc, char **argv)
 {
 
     
-    char *detectfolder = find_char_arg(argc, argv, "-folder_name", "./imagestodetect/");
+    //char *detectfolder = find_char_arg(argc, argv, "-folder_name", "./imagestodetect/");
     int dont_show = find_arg(argc, argv, "-dont_show");
     int benchmark = find_arg(argc, argv, "-benchmark");
     int benchmark_layers = find_arg(argc, argv, "-benchmark_layers");

--- a/src/image.c
+++ b/src/image.c
@@ -337,9 +337,13 @@ void draw_detections_v3(image im, detection *dets, int num, float thresh, char *
     // text output
     qsort(selected_detections, selected_detections_num, sizeof(*selected_detections), compare_by_lefts);
     int i;
+    char output[100] = "";
     for (i = 0; i < selected_detections_num; ++i) {
         const int best_class = selected_detections[i].best_class;
+        
         printf("%s: %.0f%%", names[best_class],    selected_detections[i].det.prob[best_class] * 100);
+        strcat(output, names[best_class]);
+        //printf("%s",output);
         if (ext_output)
             printf("\t(left_x: %4.0f   top_y: %4.0f   width: %4.0f   height: %4.0f)\n",
                 round((selected_detections[i].det.bbox.x - selected_detections[i].det.bbox.w / 2)*im.w),
@@ -362,6 +366,21 @@ void draw_detections_v3(image im, detection *dets, int num, float thresh, char *
             }
         }
     }
+   
+
+    //saving detections to a text file
+    printf("%s", output);
+    FILE *fptr;
+    fptr = fopen("detections.txt", "a+");
+    if (fptr == NULL) {
+        printf("Error!");
+        exit(1);
+    }
+    char nextline[] = "\n";
+    strcat(output,nextline);
+    fprintf(fptr, "%s", output);
+    fclose(fptr);
+
 
     // image output
     qsort(selected_detections, selected_detections_num, sizeof(*selected_detections), compare_by_probs);
@@ -1704,3 +1723,5 @@ LIB_API void copy_image_from_bytes(image im, char *pdata)
         }
     }
 }
+
+

--- a/src/image.c
+++ b/src/image.c
@@ -1724,4 +1724,3 @@ LIB_API void copy_image_from_bytes(image im, char *pdata)
     }
 }
 
-


### PR DESCRIPTION
one can run the detection on all the images of the folder names "/imagestodetect" and save the in "detections.txt" file for further processing.

Usage - 

./darknet detector test ./cfg/obj.data ./cfg/flip0.cfg ./cust.weights ./kk.jpeg -i 0 -thresh 0.25
