### PR TITLE
Updated the code that allows to save the cropped image in result_img directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ On Linux find executable file `./darknet` in the root directory, while on Window
 * To calculate anchors: `darknet.exe detector calc_anchors data/obj.data -num_of_clusters 9 -width 416 -height 416`
 * To check accuracy mAP@IoU=50: `darknet.exe detector map data/obj.data yolo-obj.cfg backup\yolo-obj_7000.weights`
 * To check accuracy mAP@IoU=75: `darknet.exe detector map data/obj.data yolo-obj.cfg backup\yolo-obj_7000.weights -iou_thresh 0.75`
+* To save the cropped image of the object detected: [`uncomment the following lines of code`](https://github.com/shubham-shahh/darknet/blob/95ec9bd9249a7c79bf2fea06dee964365f2fb61b/src/image_opencv.cpp#L980-L996)
 
 ##### For using network video-camera mjpeg-stream with any Android smartphone
 

--- a/src/image_opencv.cpp
+++ b/src/image_opencv.cpp
@@ -977,12 +977,13 @@ extern "C" void draw_detections_cv_v3(mat_cv* mat, detection *dets, int num, flo
                 color.val[2] = blue * 256;
 
                 // you should create directory: result_img
+                //IplImage* ipltypeimg = new IplImage(*show_image);
                 //static int copied_frame_id = -1;
                 //static IplImage* copy_img = NULL;
                 //if (copied_frame_id != frame_id) {
                 //    copied_frame_id = frame_id;
-                //    if(copy_img == NULL) copy_img = cvCreateImage(cvSize(show_img->width, show_img->height), show_img->depth, show_img->nChannels);
-                //    cvCopy(show_img, copy_img, 0);
+                //    if(copy_img == NULL) copy_img = cvCreateImage(cvSize(ipltypeimg->width, ipltypeimg->height), ipltypeimg->depth, ipltypeimg->nChannels);
+                //    cvCopy(ipltypeimg, copy_img, 0);
                 //}
                 //static int img_id = 0;
                 //img_id++;

--- a/src/image_opencv.cpp
+++ b/src/image_opencv.cpp
@@ -977,6 +977,7 @@ extern "C" void draw_detections_cv_v3(mat_cv* mat, detection *dets, int num, flo
                 color.val[2] = blue * 256;
 
                 // you should create directory: result_img
+                //converting cv::Mat type to Iplimage type
                 //IplImage* ipltypeimg = new IplImage(*show_image);
                 //static int copied_frame_id = -1;
                 //static IplImage* copy_img = NULL;


### PR DESCRIPTION
The type of 'show_img' has been changed from 'iplimage' to 'cv::Mat' and the code to save the image in result_img dir isn't updated based on the above conversion which was causing errors while recompiling the code. 

So, I've updated that, and now one can store the detected images in result_img dir. I've also updated the Readme.md based on that