### PR TITLE
fix wrong activation function in yolov4-csp.cfg

### DIFF
--- a/cfg/yolov4-csp.cfg
+++ b/cfg/yolov4-csp.cfg
@@ -1025,7 +1025,7 @@ size=1
 stride=1
 pad=1
 filters=255
-activation=logistic
+activation=linear
 
 
 [yolo]
@@ -1139,7 +1139,7 @@ size=1
 stride=1
 pad=1
 filters=255
-activation=logistic
+activation=linear
 
 
 [yolo]
@@ -1253,7 +1253,7 @@ size=1
 stride=1
 pad=1
 filters=255
-activation=logistic
+activation=linear
 
 
 [yolo]


### PR DESCRIPTION
fix wrong activation function in yolov4-csp.cfg

@WongKinYiu 
Is there reason that you use sigmoid layer before  yolo layer?

I think model would fail regression for small objects have smaller size than anchor box.