### PR TITLE
Fixed relative paths in darknet_images.py

### DIFF
--- a/darknet_images.py
+++ b/darknet_images.py
@@ -162,7 +162,7 @@ def save_annotations(name, image, detections, class_names):
     """
     Files saved with image_name.txt and relative coordinates
     """
-    file_name = name.split(".")[:-1][0] + ".txt"
+    file_name = os.path.splitext(name)[0] + ".txt"
     with open(file_name, "w") as f:
         for label, confidence, bbox in detections:
             x, y, w, h = convert2relative(image, bbox)


### PR DESCRIPTION
### What does this pull request solve?

Solves an issue in darknet_images.py that arrises when trying to label images provided through a relative path to a folder that starts with a dot or that has hidden folders inside the path.

### Minimal reproduction instructions

run the following command:

`python3 darknet_images.py --input ./IMAGES --weights /path/to/weights --config_file /path/to/cfg --data_file path/to/data  --save_labels`


Instead of generating a .txt for each image, it generates a single file at $PWD/.txt.
