### PR TITLE
fix: frame delay

### DIFF
--- a/src/demo.c
+++ b/src/demo.c
@@ -36,6 +36,7 @@ static float demo_thresh = 0;
 static int demo_ext_output = 0;
 static long long int frame_id = 0;
 static int demo_json_port = -1;
+static bool demo_skip_frame = false;
 
 
 static int avg_frames;
@@ -59,7 +60,8 @@ void *fetch_in_thread(void *ptr)
     while (!custom_atomic_load_int(&flag_exit)) {
         while (!custom_atomic_load_int(&run_fetch_in_thread)) {
             if (custom_atomic_load_int(&flag_exit)) return 0;
-            consume_frame(cap);
+            if (demo_skip_frame)
+                consume_frame(cap);
             this_thread_yield();
         }
         int dont_close_stream = 0;    // set 1 if your IP-camera periodically turns off and turns on video-stream
@@ -169,9 +171,11 @@ void demo(char *cfgfile, char *weightfile, float thresh, float hier_thresh, int 
     if(filename){
         printf("video file: %s\n", filename);
         cap = get_capture_video_stream(filename);
+        demo_skip_frame = is_live_stream(filename);
     }else{
         printf("Webcam index: %d\n", cam_index);
         cap = get_capture_webcam(cam_index);
+        demo_skip_frame = true;
     }
 
     if (!cap) {

--- a/src/demo.c
+++ b/src/demo.c
@@ -59,6 +59,7 @@ void *fetch_in_thread(void *ptr)
     while (!custom_atomic_load_int(&flag_exit)) {
         while (!custom_atomic_load_int(&run_fetch_in_thread)) {
             if (custom_atomic_load_int(&flag_exit)) return 0;
+            consume_frame(cap);
             this_thread_yield();
         }
         int dont_close_stream = 0;    // set 1 if your IP-camera periodically turns off and turns on video-stream

--- a/src/image_opencv.cpp
+++ b/src/image_opencv.cpp
@@ -834,6 +834,15 @@ extern "C" image get_image_from_stream_letterbox(cap_cv *cap, int w, int h, int 
 }
 // ----------------------------------------
 
+extern "C" void consume_frame(cap_cv *cap){
+    cv::Mat *src = NULL;
+    src = (cv::Mat *)get_capture_frame_cv(cap);
+    if (src)
+        delete src;
+}
+// ----------------------------------------
+
+
 // ====================================================================
 // Image Saving
 // ====================================================================

--- a/src/image_opencv.h
+++ b/src/image_opencv.h
@@ -83,7 +83,7 @@ int set_capture_position_frame_cv(cap_cv *cap, int index);
 image get_image_from_stream_cpp(cap_cv *cap);
 image get_image_from_stream_resize(cap_cv *cap, int w, int h, int c, mat_cv** in_img, int dont_close);
 image get_image_from_stream_letterbox(cap_cv *cap, int w, int h, int c, mat_cv** in_img, int dont_close);
-
+void consume_frame(cap_cv *cap);
 
 // Image Saving
 void save_cv_png(mat_cv *img, const char *name);

--- a/src/utils.c
+++ b/src/utils.c
@@ -1047,3 +1047,8 @@ unsigned long custom_hash(char *str)
 
     return hash;
 }
+
+bool is_live_stream(const char * path){
+    const char *url_schema = "://";
+    return (NULL != strstr(path, url_schema));
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -5,6 +5,7 @@
 
 #include <stdio.h>
 #include <time.h>
+#include <stdbool.h>
 
 #ifndef M_PI
 #define M_PI       3.14159265358979323846   // pi
@@ -95,6 +96,7 @@ int max_int_index(int *a, int n);
 boxabs box_to_boxabs(const box* b, const int img_w, const int img_h, const int bounds_check);
 int make_directory(char *path, int mode);
 unsigned long custom_hash(char *str);
+bool is_live_stream(const char * path);
 
 #define max_val_cmp(a,b) (((a) > (b)) ? (a) : (b))
 #define min_val_cmp(a,b) (((a) < (b)) ? (a) : (b))


### PR DESCRIPTION
when use low-performance devices such as raspberry pi or jetson nano execute darknet demo, the streaming will be delayed more and more. Therefore, the darknet process need to consume frames from the image capture every time to ensure that the next frame is the latest