### PR TITLE
fix: flush buffer to weights-file when writing each layer

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -2026,6 +2026,7 @@ void save_weights_upto(network net, char *filename, int cutoff, int save_ema)
             fwrite(l.biases, sizeof(float), l.outputs, fp);
             fwrite(l.weights, sizeof(float), size, fp);
         }
+        fflush(fp);
     }
     fclose(fp);
 }


### PR DESCRIPTION
I wrote a code in python that automatically zip the weights file immediately when using darknet complete training, but I found that the file is not complete.