### PR TITLE
add automatic rebase github action

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -458,7 +458,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: darknet-vcpkg-${{ runner.os }}
-        path: ${{ runner.workspace }}/buildDirectory/Release/*.dll
+        path: ${{ runner.workspace }}/buildDirectory/*.dll
     - uses: actions/upload-artifact@v2
       with:
         name: darknet-vcpkg-${{ runner.os }}

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -458,7 +458,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: darknet-vcpkg-${{ runner.os }}
-        path: ${{ runner.workspace }}/buildDirectory/*.dll
+        path: ${{ github.workspace }}/build_release/*.dll
     - uses: actions/upload-artifact@v2
       with:
         name: darknet-vcpkg-${{ runner.os }}

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -100,23 +100,6 @@ jobs:
         LD_LIBRARY_PATH: "/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH"
       run: ./build.ps1 -UseVCPKG -DoNotUpdateVCPKG -EnableOPENCV -EnableCUDA -EnableCUDNN -DisableInteractive -DoNotUpdateDARKNET
 
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-vcpkg-cuda-${{ runner.os }}
-        path: cfg
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-vcpkg-cuda-${{ runner.os }}
-        path: data
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-vcpkg-cuda-${{ runner.os }}
-        path: ${{ github.workspace }}/*dark*
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-vcpkg-cuda-${{ runner.os }}
-        path: ${{ github.workspace }}/uselib*
-
 
   ubuntu-vcpkg-opencv3-cuda:
     runs-on: ubuntu-20.04
@@ -219,23 +202,6 @@ jobs:
         LD_LIBRARY_PATH: "/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH"
       run: ./build.ps1 -EnableOPENCV -DisableInteractive -DoNotUpdateDARKNET
 
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-${{ runner.os }}
-        path: cfg
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-${{ runner.os }}
-        path: data
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-${{ runner.os }}
-        path: ${{ github.workspace }}/*dark*
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-${{ runner.os }}
-        path: ${{ github.workspace }}/uselib*
-
 
   ubuntu-cuda:
     runs-on: ubuntu-20.04
@@ -266,23 +232,6 @@ jobs:
         CUDA_TOOLKIT_ROOT_DIR: "/usr/local/cuda"
         LD_LIBRARY_PATH: "/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH"
       run: ./build.ps1 -EnableOPENCV -EnableCUDA -EnableCUDNN -DisableInteractive -DoNotUpdateDARKNET
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-cuda-${{ runner.os }}
-        path: cfg
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-cuda-${{ runner.os }}
-        path: data
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-cuda-${{ runner.os }}
-        path: ${{ github.workspace }}/*dark*
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-cuda-${{ runner.os }}
-        path: ${{ github.workspace }}/uselib*
 
 
   ubuntu-no-ocv-cpp:
@@ -339,23 +288,6 @@ jobs:
       shell: pwsh
       run: ./build.ps1 -UseVCPKG -DoNotUpdateVCPKG -DisableInteractive -DoNotUpdateDARKNET
 
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-vcpkg-${{ runner.os }}
-        path: cfg
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-vcpkg-${{ runner.os }}
-        path: data
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-vcpkg-${{ runner.os }}
-        path: ${{ github.workspace }}/*dark*
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-vcpkg-${{ runner.os }}
-        path: ${{ github.workspace }}/uselib*
-
 
   osx:
     runs-on: macos-latest
@@ -370,23 +302,6 @@ jobs:
     - name: 'Build'
       shell: pwsh
       run: ./build.ps1 -EnableOPENCV -DisableInteractive -DoNotUpdateDARKNET
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-${{ runner.os }}
-        path: cfg
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-${{ runner.os }}
-        path: data
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-${{ runner.os }}
-        path: ${{ github.workspace }}/*dark*
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-${{ runner.os }}
-        path: ${{ github.workspace }}/uselib*
 
 
   osx-no-ocv-no-omp-cpp:
@@ -421,27 +336,6 @@ jobs:
       shell: pwsh
       run: ./build.ps1 -UseVCPKG -DoNotUpdateVCPKG -EnableOPENCV -DisableInteractive -DoNotUpdateDARKNET
 
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-vcpkg-${{ runner.os }}
-        path: cfg
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-vcpkg-${{ runner.os }}
-        path: data
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-vcpkg-${{ runner.os }}
-        path: ${{ github.workspace }}/*dark*
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-vcpkg-${{ runner.os }}
-        path: ${{ runner.workspace }}/buildDirectory/Release/*.dll
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-vcpkg-${{ runner.os }}
-        path: ${{ github.workspace }}/uselib*
-
 
   win-intlibs:
     runs-on: windows-latest
@@ -453,27 +347,6 @@ jobs:
     - name: 'Build'
       shell: pwsh
       run: ./build.ps1 -DisableInteractive -DoNotUpdateDARKNET
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-${{ runner.os }}
-        path: cfg
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-${{ runner.os }}
-        path: data
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-${{ runner.os }}
-        path: ${{ github.workspace }}/*dark*
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-${{ runner.os }}
-        path: ${{ github.workspace }}/3rdparty/pthreads/bin/*.dll
-    - uses: actions/upload-artifact@v2
-      with:
-        name: darknet-${{ runner.os }}
-        path: ${{ github.workspace }}/uselib*
 
 
   win-setup-ps1:

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,19 @@
+name: Automatic Rebase
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  rebase:
+    name: Rebase
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase') && github.event.comment.author_association == 'MEMBER'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.ps1
+++ b/build.ps1
@@ -603,7 +603,7 @@ if (-Not $EnableOPENCV_CUDA) {
 }
 
 if ($EnableCSharpWrapper) {
-  $additional_build_setup = $additional_build_setup + " -DENABLE_CSHARP_WRAPPER:BOOL=ON"
+  $AdditionalBuildSetup = $AdditionalBuildSetup + " -DENABLE_CSHARP_WRAPPER:BOOL=ON"
 }
 
 $build_folder = "./build_release"

--- a/src/csharp/CMakeLists.txt
+++ b/src/csharp/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-project(YoloWrapper LANGUAGES CSharp)
+project(YoloCSharpWrapper LANGUAGES CSharp)
 include(CSharpUtilities)
 
 add_library(${PROJECT_NAME}

--- a/src/csharp/YoloCSharpWrapper.cs
+++ b/src/csharp/YoloCSharpWrapper.cs
@@ -5,7 +5,7 @@ namespace Darknet
 {
     public class YoloWrapper : IDisposable
     {
-        private const string YoloLibraryName = "yolo_cpp_dll.dll";
+        private const string YoloLibraryName = "darknet.dll";
         private const int MaxObjects = 1000;
 
         [DllImport(YoloLibraryName, EntryPoint = "init")]


### PR DESCRIPTION
in this way, we will be able to just write `/rebase` in a comment in a PR and automatically the PR will be rebased on the newest darknet master branch. This will be very useful to reconsider old Pull Requests which are old and untested with recent modifications

To trigger automatic rebuild we would need to add a personal access token to the repository. We can consider that, or just remember that opening and closing the PR will just trigger a rebuild (see https://github.community/t/triggering-a-new-workflow-from-another-workflow/16250/37 for more details)