### PR TITLE
free_image after the detections (memory leak)

### DIFF
--- a/darknet.py
+++ b/darknet.py
@@ -175,6 +175,7 @@ def detect_image(network, class_names, image, thresh=.5, hier_thresh=.5, nms=.45
     predictions = remove_negatives(detections, class_names, num)
     predictions = decode_detection(predictions)
     free_detections(detections, num)
+    free_image(image)
     return sorted(predictions, key=lambda x: x[1])
 
 


### PR DESCRIPTION
If we do not free the image and use the network to run in a loop, the memory (RAM) is eaten up very quickly. It's necessary to release memory after the detection has been performed on an image.