### PR TITLE
Made inference faster (this is especially useful when using Yolo9000)

### DIFF
--- a/include/darknet.h
+++ b/include/darknet.h
@@ -899,6 +899,7 @@ typedef struct ious {
 typedef struct detection{
     box bbox;
     int classes;
+    int best_class_idx;
     float *prob;
     float *mask;
     float objectness;

--- a/src/network.c
+++ b/src/network.c
@@ -885,7 +885,13 @@ void custom_get_region_detections(layer l, int w, int h, int net_w, int net_h, f
         dets[j].classes = l.classes;
         dets[j].bbox = boxes[j];
         dets[j].objectness = 1;
+        float highest_prob = 0;
+        dets[j].best_class_idx = -1;
         for (i = 0; i < l.classes; ++i) {
+            if (probs[j][i] > highest_prob) {
+            	highest_prob = probs[j][i];
+            	dets[j].best_class_idx = i;
+            }
             dets[j].prob[i] = probs[j][i];
         }
     }


### PR DESCRIPTION
If you look at remove_negatives in darknet.py, it gives you the final detections for an image after going through a nested loop. The outer loop iterates through all the output detection objects given by the neural net and then the inner loop iterates through all the class names (since one of the outputs of the neural net is an array of probabilities whose size is equal to the number of all classes). This is not much of an issue if you have just 80 class names (the original COCO). But, with YOLO9000, you have 9418 class names. So, iterating through almost 9k names for each detection object causes a significant slowdown.

In network.c, I keep track of the class index that gives the highest probability value. Then, in remove_negatives_faster, instead of iterating through all class indices (9418 in the case of YOLO9000), I just grab the index with the highest probability value (called the best_class_idx). Furthermore, the nms method provided is quite slow. So, I decided to provide an extra function that can do nms in python but much faster.

You will notice that all the changes in this fork have already been provided in this [issue](https://github.com/AlexeyAB/darknet/issues/7978). The person who opened that issue is actually me but I was using my work account. I will post in that comment action to prove it. On my public LinkedIn, I always advertise my personal Github account, hence why I am using it to make this commit and not my work account.