### PR TITLE
Link cuda.lib using a preprocessor macro only for non-CMake

### DIFF
--- a/src/dark_cuda.c
+++ b/src/dark_cuda.c
@@ -18,14 +18,13 @@ int gpu_index = 0;
 #include <cuda.h>
 #include <stdio.h>
 
+#ifndef USE_CMAKE_LIBS
 #pragma comment(lib, "cuda.lib")
 
-
 #ifdef CUDNN
-#ifndef USE_CMAKE_LIBS
 #pragma comment(lib, "cudnn.lib")
-#endif  // USE_CMAKE_LIBS
 #endif  // CUDNN
+#endif  // USE_CMAKE_LIBS
 
 #if defined(CUDNN_HALF) && !defined(CUDNN)
 #error "If you set CUDNN_HALF=1 then you must set CUDNN=1"


### PR DESCRIPTION
Debian CUDA packages don't ship a shim for the Windows SO cuda.lib, so compilation fails.
For CMake it's actually linked using targets, so avoid the preprocessor macro in that case.