### PR TITLE
changes to crop detections in video

### DIFF
--- a/src/image_opencv.cpp
+++ b/src/image_opencv.cpp
@@ -977,21 +977,23 @@ extern "C" void draw_detections_cv_v3(mat_cv* mat, detection *dets, int num, flo
                 color.val[2] = blue * 256;
 
                 // you should create directory: result_img
-                //static int copied_frame_id = -1;
-                //static IplImage* copy_img = NULL;
-                //if (copied_frame_id != frame_id) {
+                // static int copied_frame_id = -1;
+                // // static IplImage* copy_img = NULL;
+                // if (copied_frame_id != frame_id) {
                 //    copied_frame_id = frame_id;
-                //    if(copy_img == NULL) copy_img = cvCreateImage(cvSize(show_img->width, show_img->height), show_img->depth, show_img->nChannels);
-                //    cvCopy(show_img, copy_img, 0);
-                //}
-                //static int img_id = 0;
-                //img_id++;
-                //char image_name[1024];
-                //sprintf(image_name, "result_img/img_%d_%d_%d_%s.jpg", frame_id, img_id, class_id, names[class_id]);
-                //CvRect rect = cvRect(pt1.x, pt1.y, pt2.x - pt1.x, pt2.y - pt1.y);
-                //cvSetImageROI(copy_img, rect);
-                //cvSaveImage(image_name, copy_img, 0);
-                //cvResetImageROI(copy_img);
+                //    // if(copy_img == NULL) copy_img = cvCreateImage(cvSize(show_img->width, show_img->height), show_img->depth, show_img->nChannels);
+                //    // cvCopy(show_img, copy_img, 0);
+                // }
+                // static int img_id = 0;
+                // img_id++;
+                // char image_name[1024];
+                // sprintf(image_name, "result_img/img_%d_%d_%d_%s.jpg", frame_id, img_id, class_id, names[class_id]);
+                // CvRect rect = cvRect(pt1.x, pt1.y, pt2.x - pt1.x, pt2.y - pt1.y);
+                // cv::Mat copy_image = (*show_img)(rect);
+                // cv::imwrite(image_name, copy_image);
+                // // cvSetImageROI(copy_img, rect);
+                // // cvSaveImage(image_name, copy_img, 0);
+                // // cvResetImageROI(copy_img);
 
                 cv::rectangle(*show_img, pt1, pt2, color, width, 8, 0);
                 if (ext_output)


### PR DESCRIPTION
Keeping this in mind 
[](https://github.com/AlexeyAB/darknet/pull/7282)

proposing a simple solution.

show_img is Mat pointer. Just cropping desired portion out of it.
Useful for cropping detections in video, when src/image_opencv.cpp is used instead of src/image.cpp