### PR TITLE
Fix cmake config for windows

### DIFF
--- a/DarknetConfig.cmake.in
+++ b/DarknetConfig.cmake.in
@@ -24,7 +24,7 @@ set(CMAKE_THREAD_PREFER_PTHREAD ON)
 find_dependency(Threads)
 
 if(MSVC)
-  find_dependency(PThreads_windows)
+  find_dependency(PThreads4W)
   set(CMAKE_CXX_FLAGS "/wd4018 /wd4244 /wd4267 /wd4305 ${CMAKE_CXX_FLAGS}")
 endif()
 


### PR DESCRIPTION
darknets cmake config references the old PThread_windows file. that has been renamed in https://github.com/AlexeyAB/darknet/pull/7891 but not in the Config.cmake.in file...