### PR TITLE
[CI] build dependencies in release-only mode

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -3,6 +3,11 @@ name: Darknet Continuous Integration
 on:
   push:
   workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
   schedule:
     - cron: '0 0 * * *'
 
@@ -70,6 +75,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
     - uses: lukka/get-cmake@latest
 
@@ -370,6 +379,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+
     - name: Install dependencies
       run: brew install libomp yasm nasm
 
@@ -464,6 +477,10 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
+
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
     - uses: lukka/get-cmake@latest
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -396,7 +396,7 @@ jobs:
 
     - name: 'Build'
       shell: pwsh
-      run: ${{ github.workspace }}/build.ps1 -UseVCPKG -DoNotUpdateVCPKG -DisableInteractive -DoNotUpdateDARKNET
+      run: ${{ github.workspace }}/build.ps1 -UseVCPKG -DoNotUpdateVCPKG -EnableOPENCV -DisableInteractive -DoNotUpdateDARKNET
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -409,7 +409,7 @@ jobs:
 
     - name: 'Build'
       shell: pwsh
-      run: ${{ github.workspace }}/build.ps1 -UseVCPKG -DoNotUpdateVCPKG -EnableOPENCV -DisableInteractive -DoNotUpdateDARKNET
+      run: ${{ github.workspace }}/build.ps1 -UseVCPKG -DoNotUpdateVCPKG -DisableInteractive -DoNotUpdateDARKNET
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -291,7 +291,7 @@ jobs:
 
     - name: 'Build'
       shell: pwsh
-      run: ${{ github.workspace }}/build.ps1 -UseVCPKG -DoNotUpdateVCPKG -DisableInteractive -DoNotUpdateDARKNET
+      run: ${{ github.workspace }}/build.ps1 -UseVCPKG -DoNotUpdateVCPKG -EnableCUDNN -DisableInteractive -DoNotUpdateDARKNET
 
 
   osx:

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -291,7 +291,7 @@ jobs:
 
     - name: 'Build'
       shell: pwsh
-      run: ${{ github.workspace }}/build.ps1 -UseVCPKG -DoNotUpdateVCPKG -EnableCUDNN -DisableInteractive -DoNotUpdateDARKNET
+      run: ${{ github.workspace }}/build.ps1 -UseVCPKG -DoNotUpdateVCPKG -DisableInteractive -DoNotUpdateDARKNET
 
 
   osx:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,11 @@ option(VCPKG_USE_OPENCV2 "Use legacy OpenCV 2" OFF)
 option(VCPKG_USE_OPENCV3 "Use legacy OpenCV 3" OFF)
 option(VCPKG_USE_OPENCV4 "Use OpenCV 4" ON)
 
+if(DEFINED ENV{VCPKG_DEFAULT_TRIPLET})
+  message(STATUS "Setting default vcpkg target triplet to $ENV{VCPKG_DEFAULT_TRIPLET}")
+  set(VCPKG_TARGET_TRIPLET $ENV{VCPKG_DEFAULT_TRIPLET})
+endif()
+
 if(VCPKG_USE_OPENCV4 AND VCPKG_USE_OPENCV2)
   message(STATUS "You required vcpkg feature related to OpenCV 2 but forgot to turn off those for OpenCV 4, doing that for you")
   set(VCPKG_USE_OPENCV4 OFF CACHE BOOL "Use OpenCV 4" FORCE)

--- a/build.ps1
+++ b/build.ps1
@@ -288,7 +288,7 @@ if (($IsLinux -or $IsMacOS) -and ($ForceGCCVersion -gt 0)) {
 }
 
 if (($IsWindows -or $IsWindowsPowerShell) -and (-Not $env:VCPKG_DEFAULT_TRIPLET)) {
-  $env:VCPKG_DEFAULT_TRIPLET = "x64-windows"
+  $env:VCPKG_DEFAULT_TRIPLET = "x64-windows-release"
 }
 
 if ($EnableCUDA) {

--- a/build.ps1
+++ b/build.ps1
@@ -290,6 +290,12 @@ if (($IsLinux -or $IsMacOS) -and ($ForceGCCVersion -gt 0)) {
 if (($IsWindows -or $IsWindowsPowerShell) -and (-Not $env:VCPKG_DEFAULT_TRIPLET)) {
   $env:VCPKG_DEFAULT_TRIPLET = "x64-windows-release"
 }
+elseif ($IsMacOS -and (-Not $env:VCPKG_DEFAULT_TRIPLET)) {
+  $env:VCPKG_DEFAULT_TRIPLET = "x64-osx-release"
+}
+elseif ($IsLinux -and (-Not $env:VCPKG_DEFAULT_TRIPLET)) {
+  $env:VCPKG_DEFAULT_TRIPLET = "x64-linux-release"
+}
 
 if ($EnableCUDA) {
   if ($IsMacOS) {


### PR DESCRIPTION
saves time and avoid failures due to full storage on GitHub Actions Runners