### PR TITLE
add generic dataset folder structure parsing

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -275,6 +275,8 @@ void replace_image_to_label(const char* input_path, char* output_path)
     //find_replace(output_path, "/images/", "/labels/", output_path);    // COCO
     //find_replace(output_path, "/VOC2007/JPEGImages/", "/VOC2007/labels/", output_path);        // PascalVOC
     //find_replace(output_path, "/VOC2012/JPEGImages/", "/VOC2012/labels/", output_path);        // PascalVOC
+    
+    find_replace(output_path, "/ims/", "/anns/", output_path); // generic dataset
 
     //find_replace(output_path, "/raw/", "/labels/", output_path);
     trim(output_path);


### PR DESCRIPTION
## why?

custom dataset may not respect either voc or coco folder structure. This PR let the user put images and annotations in `ims` and `anns` folders respectively

I've been doing this change (for years now) every time I pull the latest master, it would be handy to have it in the official version

A possible alternative would be to let the user specify in the config the names of the folders, but this change would be more involved.