### PR TITLE
Allow passing image to image_detection()

### DIFF
--- a/darknet_images.py
+++ b/darknet_images.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import glob
 import random
-import darknet
 import time
 import cv2
 import numpy as np
@@ -97,14 +96,17 @@ def prepare_batch(images, network, channels=3):
     return darknet.IMAGE(width, height, channels, darknet_images)
 
 
-def image_detection(image_path, network, class_names, class_colors, thresh):
+def image_detection(image_or_path, network, class_names, class_colors, thresh):
     # Darknet doesn't accept numpy images.
     # Create one with image we reuse for each detect
     width = darknet.network_width(network)
     height = darknet.network_height(network)
     darknet_image = darknet.make_image(width, height, 3)
 
-    image = cv2.imread(image_path)
+    if type(image_or_path) == "str":
+        image = cv2.imread(image_or_path)
+    else:
+        image = image_or_path
     image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
     image_resized = cv2.resize(image_rgb, (width, height),
                                interpolation=cv2.INTER_LINEAR)


### PR DESCRIPTION
I'm doing some refactoring of The Spaghetti Detective, a service that uses YOLO to detect images of 3d printer "spaghetti" and stop the printer when it's failing (details at https://github.com/TheSpaghettiDetective/TheSpaghettiDetective/issues/552).

I'd like to eliminate some old code there and rely on `darknet_images.py` in this repo, but we receive the image via URL and don't have a file to load in. Rather than writing it to a tmpdir and reading it back in again, I'd prefer to pass the image directly, which is possible with this PR.

I also removed a duplicate import - `darknet` is imported twice (line 5 and line 8 of the original) which caused a weird error.