### PR TITLE
Fix weight initialization in make_convolutional_layer

### DIFF
--- a/src/convolutional_layer.c
+++ b/src/convolutional_layer.c
@@ -579,7 +579,7 @@ convolutional_layer make_convolutional_layer(int batch, int steps, int h, int w,
         for (i = 0; i < l.nweights; ++i) l.weights[i] = 1;   // rand_normal();
     }
     else {
-        for (i = 0; i < l.nweights; ++i) l.weights[i] = scale*rand_uniform(-1, 1);   // rand_normal();
+//        for (i = 0; i < l.nweights; ++i) l.weights[i] = scale*rand_uniform(-1, 1);   // rand_normal();
     }
     int out_h = convolutional_out_height(l);
     int out_w = convolutional_out_width(l);


### PR DESCRIPTION
Hi, I have a tiny opinion and present it.
The make_convolutional_layer function of convolutional_layer.c allocates memory to contain the weights parameter and puts in a random initial value. 
However, since the convolutional layer gets the parameters of the weights file from the load_wieghts function, there is no need to initialize it. 
Because of the execution of inserting a random initial value, it takes a long time to initialize the darknet. 
I commented out this part to shorten the initialization time.

So, please take a look at what I fixed.