### PR TITLE
Updated the minimum version of CMake to 3.16 from 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.16)
 include(CMakeDependentOption)
 
 set(Darknet_MAJOR_VERSION 0)


### PR DESCRIPTION
This is done because the latest CMake version of Ubuntu stable is 3.16 and it causes error when we use 3.18.
Also, the cmake does not cause any errors with 3.16 and thus it does not need any specific feature that 3.18 provides but 3.16 does not provide.

![image](https://user-images.githubusercontent.com/51186433/164437511-b5c5535e-065d-4b45-ba3c-a80ee1b3504f.png)
