### PR TITLE
Fix segfault for batch_detection_example

### DIFF
--- a/darknet_images.py
+++ b/darknet_images.py
@@ -79,7 +79,7 @@ def load_images(images_path):
             glob.glob(os.path.join(images_path, "*.jpeg"))
 
 
-def prepare_batch(images, network, channels=3):
+def prepare_batch(images, network):
     width = darknet.network_width(network)
     height = darknet.network_height(network)
 
@@ -93,9 +93,7 @@ def prepare_batch(images, network, channels=3):
 
     batch_array = np.concatenate(darknet_images, axis=0)
     batch_array = np.ascontiguousarray(batch_array.flat, dtype=np.float32)/255.0
-    darknet_images = batch_array.ctypes.data_as(darknet.POINTER(darknet.c_float))
-    return darknet.IMAGE(width, height, channels, darknet_images)
-
+    return batch_array
 
 def image_detection(image_path, network, class_names, class_colors, thresh):
     # Darknet doesn't accept numpy images.
@@ -119,7 +117,9 @@ def image_detection(image_path, network, class_names, class_colors, thresh):
 def batch_detection(network, images, class_names, class_colors,
                     thresh=0.25, hier_thresh=.5, nms=.45, batch_size=4):
     image_height, image_width, _ = check_batch_shape(images, batch_size)
-    darknet_images = prepare_batch(images, network)
+    batch_array = prepare_batch(images, network)
+    batch_array = batch_array.ctypes.data_as(darknet.POINTER(darknet.c_float))
+    darknet_images = darknet.IMAGE(image_width, image_height, 3, batch_array)
     batch_detections = darknet.network_predict_batch(network, darknet_images, batch_size, image_width,
                                                      image_height, thresh, hier_thresh, None, 0, 0)
     batch_predictions = []


### PR DESCRIPTION
I try to run the `batch_detection_example` function from the `darknet_images.py` and faced with a segmentation fault in the function `batch_detection` in the `darknet.network_predict_batch` call.
```
def batch_detection(network, images, class_names, class_colors,
                    thresh=0.25, hier_thresh=.5, nms=.45, batch_size=4):
    image_height, image_width, _ = check_batch_shape(images, batch_size)
    darknet_images = prepare_batch(images, network)
    batch_detections = darknet.network_predict_batch(network, darknet_images, batch_size, image_width,
                                                     image_height, thresh, hier_thresh, None, 0, 0)
```

The problem is that function `prepare_batch` return a pointer `darknet_images` to the `batch_array` in the `darknet.IMAGE` structure but not the 'batch_array' itself. 
```
def prepare_batch(images, network, channels=3):
    ...
    batch_array = np.concatenate(darknet_images, axis=0)
    batch_array = np.ascontiguousarray(batch_array.flat, dtype=np.float32)/255.0
    darknet_images = batch_array.ctypes.data_as(darknet.POINTER(darknet.c_float))
    return darknet.IMAGE(width, height, channels, darknet_images)
```

So in the function `batch_detection` the `darknet_images` point to the invalid memory.
It seems that garbage collector erase the `batch_array` after the `prepare_batch` return.

In the PR I moved wrapping of the `batch_array` from the `prepare_batch` function into the 'batch_detection' function.