### PR TITLE
remove redundant device memroy copy

### DIFF
--- a/src/convolutional_layer.c
+++ b/src/convolutional_layer.c
@@ -708,7 +708,7 @@ convolutional_layer make_convolutional_layer(int batch, int steps, int h, int w,
             l.bias_updates_gpu = l.share_layer->bias_updates_gpu;
         }
         else {
-            l.weights_gpu = cuda_make_array(l.weights, l.nweights);
+            l.weights_gpu = cuda_make_array(0, l.nweights);
             if (train) l.weight_updates_gpu = cuda_make_array(l.weight_updates, l.nweights);
 #ifdef CUDNN_HALF
             l.weights_gpu16 = cuda_make_array(NULL, l.nweights / 2 + 1);


### PR DESCRIPTION
Hi there, I wrote a GPU device memory profiling tool and found there always is an extra memory copy for the `l.weights_gpu` during making each convolutional layer. After I check the code, I found that `l.weights_gpu` will be flushed and filled during the later `load_weights` function. In this case, we don't need the former memory copy during parsing the convolutional layers in inference. I modified it and worked well on my side. Does this make any sense?