### PR TITLE
Fix yolo_cpp_dll_no_gpu.vcxproj build failure

### DIFF
--- a/build/darknet/yolo_cpp_dll_no_gpu.vcxproj
+++ b/build/darknet/yolo_cpp_dll_no_gpu.vcxproj
@@ -214,6 +214,7 @@
     <ClCompile Include="..\..\src\rnn.c" />
     <ClCompile Include="..\..\src\rnn_layer.c" />
     <ClCompile Include="..\..\src\rnn_vid.c" />
+    <ClCompile Include="..\..\src\representation_layer.c" />
     <ClCompile Include="..\..\src\route_layer.c" />
     <ClCompile Include="..\..\src\sam_layer.c" />
     <ClCompile Include="..\..\src\scale_channels_layer.c" />
@@ -275,6 +276,7 @@
     <ClInclude Include="..\..\src\parser.h" />
     <ClInclude Include="..\..\src\region_layer.h" />
     <ClInclude Include="..\..\src\reorg_layer.h" />
+    <ClInclude Include="..\..\src\representation_layer.h" />
     <ClInclude Include="..\..\src\reorg_old_layer.h" />
     <ClInclude Include="..\..\src\rnn_layer.h" />
     <ClInclude Include="..\..\src\route_layer.h" />


### PR DESCRIPTION
Source file was missing from project (there already is an issue: #8529).

The fact that noone else noticed makes me wonder:

1. Is this project still used / maintained / supported ?

2. Are any of the *.vcxproj*s still used / maintained / supported?

If the answer to the questions is "yes", would it make sense to make further improvements to them?

