### PR TITLE
typo fix for show_image save option

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -705,7 +705,7 @@ void show_image(image p, const char *name)
 #ifdef OPENCV
     show_image_cv(p, name);
 #else
-    fprintf(stderr, "Not compiled with OpenCV, saving to %s.png instead\n", name);
+    fprintf(stderr, "Not compiled with OpenCV, saving to %s.jpg instead\n", name);
     save_image(p, name);
 #endif  // OPENCV
 }


### PR DESCRIPTION
Hi, I have a tiny typo fix here, the default image type for save_image is jpg instead of png.

caller
https://github.com/AlexeyAB/darknet/blob/eaee5060d55377f566310b9dc84e5605e1cccccf/src/image.c#L708-L709
callee
https://github.com/AlexeyAB/darknet/blob/eaee5060d55377f566310b9dc84e5605e1cccccf/src/image.c#L755-L758