### PR TITLE
add file existence check in yolo_console_dll.cpp

### DIFF
--- a/src/yolo_console_dll.cpp
+++ b/src/yolo_console_dll.cpp
@@ -23,6 +23,7 @@
 #include "yolo_v2_class.hpp"    // imported functions from DLL
 
 #ifdef OPENCV
+#include <sys/stat.h>   // check if file exists
 #ifdef ZED_STEREO
 #include <sl/Camera.hpp>
 #if ZED_SDK_MAJOR_VERSION == 2
@@ -666,6 +667,14 @@ int main(int argc, char *argv[])
 
             }
             else {    // image file
+                // check if file exists
+                struct stat info;
+                if (stat(filename.c_str(), &info) != 0) {
+                    filename.clear();
+                    std::cout << "File not found! Please check the file path..." << std::endl;
+                    continue;
+                }
+
                 // to achive high performance for multiple images do these 2 lines in another thread
                 cv::Mat mat_img = cv::imread(filename);
                 auto det_image = detector.mat_to_image_resize(mat_img);


### PR DESCRIPTION
I'm trying to use C++ API to integrate darknet with my C++ project on windows. I followed the tutorial on [this topic](https://github.com/AlexeyAB/darknet#how-to-use-yolo-as-dll-and-so-libraries) in README.md.

During the test toward my input image files (with `#define OPENCV`), I found that whenever I gave the wrong file path, the console crashed because the given file path did not exist. To be more convenient for input image files testing, I implemented the file existence check section in yolo_console_dll.cpp.