### PR TITLE
fix double free or corruption

### DIFF
--- a/src/detector.c
+++ b/src/detector.c
@@ -827,7 +827,7 @@ void validate_detector(char *datacfg, char *cfgfile, char *weightfile, char *out
         fseek(fp, -2, SEEK_CUR);
 #endif
         fprintf(fp, "\n]\n");
-        fclose(fp);
+        // fclose(fp);
     }
 
     if (fp) fclose(fp);


### PR DESCRIPTION
Fix double free memory when "eval=bdd" 



