### PR TITLE
Move set_batch_network to public API

### DIFF
--- a/include/darknet.h
+++ b/include/darknet.h
@@ -1032,6 +1032,7 @@ LIB_API void diounms_sort(detection *dets, int total, int classes, float thresh,
 // network.h
 LIB_API float *network_predict(network net, float *input);
 LIB_API float *network_predict_ptr(network *net, float *input);
+LIB_API void set_batch_network(network *net, int b);
 LIB_API detection *get_network_boxes(network *net, int w, int h, float thresh, float hier, int *map, int relative, int *num, int letter);
 LIB_API det_num_pair* network_predict_batch(network *net, image im, int batch_size, int w, int h, float thresh, float hier, int *map, int relative, int letter);
 LIB_API void free_detections(detection *dets, int n);

--- a/src/network.h
+++ b/src/network.h
@@ -144,7 +144,7 @@ int get_predicted_class_network(network net);
 void print_network(network net);
 void visualize_network(network net);
 int resize_network(network *net, int w, int h);
-void set_batch_network(network *net, int b);
+//LIB_API void set_batch_network(network *net, int b);
 int get_network_input_size(network net);
 float get_network_cost(network net);
 //LIB_API layer* get_network_layer(network* net, int i);


### PR DESCRIPTION
I have just updated a [ROS 2 package that uses Darknet](
https://github.com/ros2/openrobotics_darknet_ros/) to work with its latest version, [Humble](https://docs.ros.org/en/humble/index.html). Previously it was using [Joseph Redmon's original version of Darknet](https://github.com/pjreddie/darknet) and was using the **`set_batch_network`** function which in this version is not part of the **public API**. This pull request simply exposes this function and as such is related to https://github.com/AlexeyAB/darknet/issues/2956, https://github.com/AlexeyAB/darknet/issues/3924 and the corresponding pull request https://github.com/AlexeyAB/darknet/pull/3465.