### PR TITLE
Allow repository to be used with ROS/ROS 2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>darknet</name>
+  <version>0.1.0</version>
+  <description>Darknet, an open source neural network framework.</description>
+
+  <author email="you@example.com">Joseph Redmon</author>
+  <maintainer email="you@example.com">Alexey Bochkovskiy</maintainer>
+
+  <license>YOLO license</license>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <depend>libopencv-dev</depend>
+
+  <!-- nvidia-cuda-dev is just the libraries to link against -->
+  <exec_depend>nvidia-cuda-dev</exec_depend>
+
+  <!-- nvidia-cuda includes nvidia-cuda-dev plus the nvcc compiler -->
+  <build_depend>nvidia-cuda</build_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>
+


### PR DESCRIPTION
This pull request allows this repository to be used directly with the popular [**robotics middleware ROS**](https://www.ros.org/) by providing a **manifest** `package.xml`, a simple text file containing its dependencies, that is compatible with [ROS](http://wiki.ros.org/catkin/package.xml) as well as [ROS 2](https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Colcon-Tutorial.html). Previously this was only possible through wrappers such as [`darknet_ros`](https://github.com/leggedrobotics/darknet_ros) or [`darknet_vendor`](https://github.com/ros2/darknet_vendor) that use [the initial Darknet](https://github.com/pjreddie/darknet) which is no longer actively maintained. This is related to previous issue https://github.com/AlexeyAB/darknet/issues/5457.

This change makes integrating Darknet into robotics applications much more convenient. It is sufficient to make the `package.xml` of any package depending on Darknet with `<depend>darknet</depend>` and linking to it inside the `CMakeList.txt` with:

```
find_package(Darknet REQUIRED)
include_directories(
  ${Darknet_INCLUDE_DIR}
)
link_libraries(Darknet::dark)
```
Additionally [`INSTALL_RPATH_USE_LINK_PATH`](https://cmake.org/cmake/help/v3.0/command/set_target_properties.html) might have to be set.
