### PR TITLE
better logging for filename/function/line on CUDA and CUDNN error; lo…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ NVCC=nvcc
 OPTS=-Ofast
 LDFLAGS= -lm -pthread
 COMMON= -Iinclude/ -I3rdparty/stb/include
-CFLAGS=-Wall -Wfatal-errors -Wno-unused-result -Wno-unknown-pragmas -fPIC
+CFLAGS=-Wall -Wfatal-errors -Wno-unused-result -Wno-unknown-pragmas -fPIC -rdynamic
 
 ifeq ($(DEBUG), 1)
 #OPTS= -O0 -g

--- a/src/dark_cuda.c
+++ b/src/dark_cuda.c
@@ -54,7 +54,7 @@ void *cuda_get_context()
     return (void *)pctx;
 }
 
-void check_error(cudaError_t status)
+void check_error(cudaError_t status, const char * const filename, const char * const funcname, const int line)
 {
     cudaError_t status2 = cudaGetLastError();
     if (status != cudaSuccess)
@@ -66,7 +66,7 @@ void check_error(cudaError_t status)
 #ifdef WIN32
         getchar();
 #endif
-        error(buffer, DARKNET_LOC);
+        error(buffer, filename, funcname, line);
     }
     if (status2 != cudaSuccess)
     {
@@ -77,15 +77,15 @@ void check_error(cudaError_t status)
 #ifdef WIN32
         getchar();
 #endif
-        error(buffer, DARKNET_LOC);
+        error(buffer, filename, funcname, line);
     }
 }
 
-void check_error_extended(cudaError_t status, const char *file, int line, const char *date_time)
+void check_error_extended(cudaError_t status, const char * const filename, const char * const funcname, const int line)
 {
     if (status != cudaSuccess) {
-        printf("CUDA status Error: file: %s() : line: %d : build time: %s \n", file, line, date_time);
-        check_error(status);
+        printf("CUDA status Error: file: %s: func: %s() line: %d\n", filename, funcname, line);
+        check_error(status, filename, funcname, line);
     }
 #if defined(DEBUG) || defined(CUDA_DEBUG)
     cuda_debug_sync = 1;
@@ -93,9 +93,9 @@ void check_error_extended(cudaError_t status, const char *file, int line, const 
     if (cuda_debug_sync) {
         status = cudaDeviceSynchronize();
         if (status != cudaSuccess)
-            printf("CUDA status = cudaDeviceSynchronize() Error: file: %s() : line: %d : build time: %s \n", file, line, date_time);
+            printf("CUDA status = cudaDeviceSynchronize() Error: file: %s: func: %s() line: %d\n", filename, funcname, line);
     }
-    check_error(status);
+    check_error(status, filename, funcname, line);
 }
 
 dim3 cuda_gridsize(size_t n){
@@ -180,7 +180,7 @@ cudnnHandle_t cudnn_handle()
 }
 
 
-void cudnn_check_error(cudnnStatus_t status)
+void cudnn_check_error(cudnnStatus_t status, const char * const filename, const char * const function, const int line)
 {
 #if defined(DEBUG) || defined(CUDA_DEBUG)
     cudaDeviceSynchronize();
@@ -201,7 +201,7 @@ void cudnn_check_error(cudnnStatus_t status)
 #ifdef WIN32
         getchar();
 #endif
-        error(buffer, DARKNET_LOC);
+        error(buffer, filename, function, line);
     }
     if (status2 != CUDNN_STATUS_SUCCESS)
     {
@@ -212,15 +212,15 @@ void cudnn_check_error(cudnnStatus_t status)
 #ifdef WIN32
         getchar();
 #endif
-        error(buffer, DARKNET_LOC);
+        error(buffer, filename, function, line);
     }
 }
 
-void cudnn_check_error_extended(cudnnStatus_t status, const char *file, int line, const char *date_time)
+void cudnn_check_error_extended(cudnnStatus_t status, const char * const filename, const char * const function, const int line)
 {
     if (status != CUDNN_STATUS_SUCCESS) {
-        printf("\n cuDNN status Error in: file: %s() : line: %d : build time: %s \n", file, line, date_time);
-        cudnn_check_error(status);
+        printf("\n cuDNN status Error in: file: %s function: %s() line: %d\n", filename, function, line);
+        cudnn_check_error(status, filename, function, line);
     }
 #if defined(DEBUG) || defined(CUDA_DEBUG)
     cuda_debug_sync = 1;
@@ -228,9 +228,9 @@ void cudnn_check_error_extended(cudnnStatus_t status, const char *file, int line
     if (cuda_debug_sync) {
         cudaError_t status = cudaDeviceSynchronize();
         if (status != CUDNN_STATUS_SUCCESS)
-            printf("\n cudaError_t status = cudaDeviceSynchronize() Error in: file: %s() : line: %d : build time: %s \n", file, line, date_time);
+            printf("\n cudaError_t status = cudaDeviceSynchronize() Error in: file: %s function: %s() line: %d\n", filename, function, line);
     }
-    cudnn_check_error(status);
+    cudnn_check_error(status, filename, function, line);
 }
 
 static cudnnHandle_t switchCudnnHandle[16];
@@ -251,10 +251,10 @@ void cublas_check_error(cublasStatus_t status)
     }
 }
 
-void cublas_check_error_extended(cublasStatus_t status, const char *file, int line, const char *date_time)
+void cublas_check_error_extended(cublasStatus_t status, const char * const filename, const char * const function, const int line)
 {
     if (status != CUBLAS_STATUS_SUCCESS) {
-      printf("\n cuBLAS status Error in: file: %s() : line: %d : build time: %s \n", file, line, date_time);
+      printf("\n cuBLAS status Error in: file: %s function: %s() line: %d\n", filename, function, line);
     }
 #if defined(DEBUG) || defined(CUDA_DEBUG)
     cuda_debug_sync = 1;
@@ -262,7 +262,7 @@ void cublas_check_error_extended(cublasStatus_t status, const char *file, int li
     if (cuda_debug_sync) {
         cudaError_t status = cudaDeviceSynchronize();
       if (status != CUDA_SUCCESS)
-          printf("\n cudaError_t status = cudaDeviceSynchronize() Error in: file: %s() : line: %d : build time: %s \n", file, line, date_time);
+          printf("\n cudaError_t status = cudaDeviceSynchronize() Error in: file: %s function: %s() line: %d\n", filename, function, line);
     }
     cublas_check_error(status);
 }
@@ -602,7 +602,7 @@ void cuda_pull_array_async(float *x_gpu, float *x, size_t n)
 {
     size_t size = sizeof(float)*n;
     cudaError_t status = cudaMemcpyAsync(x, x_gpu, size, cudaMemcpyDefault, get_cuda_stream());
-    check_error(status);
+    check_error(status, DARKNET_LOC);
     //cudaStreamSynchronize(get_cuda_stream());
 }
 

--- a/src/dark_cuda.h
+++ b/src/dark_cuda.h
@@ -54,11 +54,11 @@ extern int gpu_index;
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
-    void check_error(cudaError_t status);
-    void check_error_extended(cudaError_t status, const char *file, int line, const char *date_time);
-    void cublas_check_error_extended(cublasStatus_t status, const char *file, int line, const char *date_time);
-#define CHECK_CUDA(X) check_error_extended(X, __FILE__ " : " __FUNCTION__, __LINE__,  __DATE__ " - " __TIME__ );
-#define CHECK_CUBLAS(X) cublas_check_error_extended(X, __FILE__ " : " __FUNCTION__, __LINE__,  __DATE__ " - " __TIME__ );
+    void check_error(cudaError_t status, const char * const filename, const char * const funcname, const int line);
+    void check_error_extended(cudaError_t status, const char * const filename, const char * const funcname, const int line);
+    void cublas_check_error_extended(cublasStatus_t status, const char * const filename, const char * const funcname, const int line);
+#define CHECK_CUDA(X) check_error_extended(X, __FILE__, __func__, __LINE__ );
+#define CHECK_CUBLAS(X) cublas_check_error_extended(X, __FILE__, __func__, __LINE__ );
 
     cublasHandle_t blas_handle();
     void free_pinned_memory();
@@ -92,8 +92,8 @@ extern "C" {
 cudnnHandle_t cudnn_handle();
 enum {cudnn_fastest, cudnn_smallest, cudnn_specify};
 
-void cudnn_check_error_extended(cudnnStatus_t status, const char *file, int line, const char *date_time);
-#define CHECK_CUDNN(X) cudnn_check_error_extended(X, __FILE__ " : " __FUNCTION__, __LINE__,  __DATE__ " - " __TIME__ );
+void cudnn_check_error_extended(cudnnStatus_t status, const char * const filename, const char * const function, const int line);
+#define CHECK_CUDNN(X) cudnn_check_error_extended(X, __FILE__, __func__, __LINE__);
 #endif
 
 #ifdef __cplusplus

--- a/src/utils.c
+++ b/src/utils.c
@@ -18,6 +18,7 @@
 #else
 #include <sys/time.h>
 #include <sys/stat.h>
+#include <execinfo.h>
 #endif
 
 
@@ -325,10 +326,30 @@ void top_k(float *a, int n, int k, int *index)
     }
 }
 
+
+void log_backtrace()
+{
+#ifndef WIN32
+    void * buffer[50];
+    int count = backtrace(buffer, sizeof(buffer));
+    char **symbols = backtrace_symbols(buffer, count);
+
+    fprintf(stderr, "backtrace (%d entries)\n", count);
+
+    for (int idx = 0; idx < count; idx ++)
+    {
+        fprintf(stderr, "%d/%d: %s\n", idx + 1, count, symbols[idx]);
+    }
+
+    free(symbols);
+#endif
+}
+
 void error(const char * const msg, const char * const filename, const char * const funcname, const int line)
 {
-    fprintf(stderr, "Darknet error location: %s, %s, line #%d\n", filename, funcname, line);
+    fprintf(stderr, "Darknet error location: %s, %s(), line #%d\n", filename, funcname, line);
     perror(msg);
+    log_backtrace();
     exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
…gging of full backtrace on Linux when an error causes Darknet to exit

For example, issue #8669 now results in this being logged showing exactly where the error is happening:

```
 calculation mAP (mean average precision)...
 Detection layer: 30 - type = 28 
 Detection layer: 37 - type = 28 
4CUDA status Error: file: ./src/network_kernels.cu: func: network_predict_gpu() line: 735

 CUDA Error: an illegal memory access was encountered
Darknet error location: ./src/network_kernels.cu, network_predict_gpu(), line #735
CUDA Error: an illegal memory access was encountered: Success
backtrace (11 entries)
1/11: src/darknet-pr/darknet(log_backtrace+0x38) [0x562adf9d1dd8]
2/11: src/darknet-pr/darknet(error+0x3d) [0x562adf9d1ebd]
3/11: src/darknet-pr/darknet(check_error+0xd0) [0x562adf9d4eb0]
4/11: src/darknet-pr/darknet(check_error_extended+0x7c) [0x562adf9d4f9c]
5/11: src/darknet-pr/darknet(network_predict_gpu+0x15f) [0x562adfad509f]
6/11: src/darknet-pr/darknet(validate_detector_map+0x9ad) [0x562adfa64f6d]
7/11: src/darknet-pr/darknet(train_detector+0x16a4) [0x562adfa67ca4]
8/11: src/darknet-pr/darknet(run_detector+0x897) [0x562adfa6bc57]
9/11: src/darknet-pr/darknet(main+0x34d) [0x562adf98663d]
10/11: /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7f433e662083]
11/11: src/darknet-pr/darknet(_start+0x2e) [0x562adf9888be]
```
